### PR TITLE
Add internal IRT implementation of execv()/execve()

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -50,7 +50,7 @@ struct NaClThreadContext *master_ctx;
  * used in NaClSysFork()
  */
 struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
-  struct NaClApp *nap_child = NaClAlignedMalloc(sizeof *nap_child, __alignof(struct NaClApp));
+  struct NaClApp *nap_child = NaClAlignedMalloc(sizeof(*nap_child), __alignof(struct NaClApp));
   struct NaClApp *nap_master = ((struct NaClAppThread *)master_ctx)->nap;
   struct NaClApp *nap_parent = nap;
   struct NaClApp *nap_arr[] = {nap_master, nap_parent};
@@ -61,7 +61,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
   CHECK(nap_child);
 
   NaClLog(1, "%s\n", "Entered NaClChildNapCtor()");
-  memset(nap_child, 0, sizeof *nap_child);
+  memset(nap_child, 0, sizeof(*nap_child));
   if (!NaClAppCtor(nap_child)) {
     NaClLog(LOG_FATAL, "%s\n", "Failed to initialize fork child nap");
   }
@@ -92,7 +92,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
   }
 
   /* store cage_ids in both master and parent to provide redundancy and avoid orphans */
-  for (size_t i = 0; i < sizeof nap_arr / sizeof *nap_arr; i++) {
+  for (size_t i = 0; i < sizeof(nap_arr) / sizeof(*nap_arr); i++) {
     if (!nap_arr[i]) {
       continue;
     }
@@ -350,7 +350,7 @@ void NaClAppThreadTeardown(struct NaClAppThread *natp) {
       nap_arr[0] = NULL;
     }
     /* remove self from parent's list of children */
-    for (size_t i = 0; i < sizeof nap_arr / sizeof *nap_arr; i++) {
+    for (size_t i = 0; i < sizeof(nap_arr) / sizeof(*nap_arr); i++) {
       if (!nap_arr[i]) {
         continue;
       }
@@ -453,7 +453,7 @@ struct NaClAppThread *NaClAppThreadMake(struct NaClApp *nap,
   struct NaClAppThread *natp;
   uint32_t tls_idx;
 
-  natp = NaClAlignedMalloc(sizeof *natp, __alignof(struct NaClAppThread));
+  natp = NaClAlignedMalloc(sizeof(*natp), __alignof(struct NaClAppThread));
   if (!natp) {
     return NULL;
   }

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -150,7 +150,7 @@ struct NaClAppThread {
   int                       dynamic_delete_generation;
 };
 
-struct NaClApp *NaClChildNapCtor(struct NaClAppThread *natp);
+struct NaClApp *NaClChildNapCtor(struct NaClApp *nap);
 
 void WINAPI NaClAppForkThreadLauncher(void *state);
 void WINAPI NaClAppThreadLauncher(void *state);

--- a/src/trusted/service_runtime/nacl_globals.h
+++ b/src/trusted/service_runtime/nacl_globals.h
@@ -129,18 +129,13 @@ void  NaClGlobalModuleFini(void);
 /* this is defined in src/trusted/service_runtime/arch/<arch>/ sel_rt.h */
 void NaClInitGlobals(void);
 
-static INLINE void NaClPatchAddr(uintptr_t child_bits,
-                                 uintptr_t parent_bits,
-                                 uintptr_t *start,
-                                 size_t cnt) {
+static INLINE void NaClPatchAddr(uintptr_t child_bits, uintptr_t parent_bits, uintptr_t *start, size_t cnt) {
   for (size_t i = 0; i < cnt; i++) {
-    /* skip addresses with matching high bits */
-    if (!((parent_bits ^ start[i]) >> NACL_PAGESHIFT)) {
+    if ((parent_bits >> NACL_PAGESHIFT) != (start[i] >> NACL_PAGESHIFT))
       continue;
-    }
-    NaClLog(2, "patching %p\n", (void *)start[i]);
+    NaClLog(1, "patching %p\n", (void *)start[i]);
     start[i] = child_bits | (start[i] & UNTRUSTED_ADDR_MASK);
-    NaClLog(2, "new addr %p\n", (void *)start[i]);
+    NaClLog(1, "new addr %p\n", (void *)start[i]);
   }
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -391,7 +391,7 @@ int32_t NaClSysThreadExit(struct NaClAppThread  *natp,
 
   if (stack_flag) {
     NaClLog(2, "aClSysThreadExit: stack_flag is %"NACL_PRIxPTR"\n", (uintptr_t)stack_flag);
-    if (!NaClCopyOutToUser(natp->nap, (uintptr_t) stack_flag, &zero, sizeof zero)) {
+    if (!NaClCopyOutToUser(natp->nap, (uintptr_t) stack_flag, &zero, sizeof(zero))) {
       NaClLog(2, "NaClSysThreadExit: ignoring invalid"
                " stack_flag 0x%"NACL_PRIxPTR"\n",
                (uintptr_t)stack_flag);
@@ -415,7 +415,7 @@ int32_t NaClSysNameService(struct NaClAppThread *natp,
           (uintptr_t) natp,
           (uintptr_t) desc_addr);
 
-  if (!NaClCopyInFromUser(nap, &desc, (uintptr_t) desc_addr, sizeof desc)) {
+  if (!NaClCopyInFromUser(nap, &desc, (uintptr_t) desc_addr, sizeof(desc))) {
     NaClLog(LOG_ERROR,
             "Invalid address argument to NaClSysNameService\n");
     retval = -NACL_ABI_EFAULT;
@@ -426,7 +426,7 @@ int32_t NaClSysNameService(struct NaClAppThread *natp,
     /* read */
     desc = NaClSetAvail(nap, NaClDescRef(nap->name_service_conn_cap));
     if (NaClCopyOutToUser(nap, (uintptr_t) desc_addr,
-                          &desc, sizeof desc)) {
+                          &desc, sizeof(desc))) {
       retval = 0;
     } else {
       retval = -NACL_ABI_EFAULT;
@@ -619,7 +619,7 @@ int32_t NaClSysOpen(struct NaClAppThread  *natp,
           "0x%08"NACL_PRIxPTR", 0x%x, 0x%x)\n",
           (uintptr_t)natp, (uintptr_t)pathname, flags, mode);
 
-  retval = CopyPathFromUser(nap, path, sizeof path, (uintptr_t)pathname);
+  retval = CopyPathFromUser(nap, path, sizeof(path), (uintptr_t)pathname);
 
   /*
    * TODO:
@@ -630,7 +630,7 @@ int32_t NaClSysOpen(struct NaClAppThread  *natp,
    *
    * -jp
    */
-  if (!memcmp(path, tls_prefix, sizeof tls_prefix - 1)) {
+  if (!memcmp(path, tls_prefix, sizeof(tls_prefix) - 1)) {
     char *left_side = path + tls_start_idx;
     char *right_side = path + tls_end_idx;
     size_t len_of_rest = strlen(right_side) + 1;
@@ -674,7 +674,7 @@ int32_t NaClSysOpen(struct NaClAppThread  *natp,
   if (!retval && S_IFDIR == (S_IFDIR & stbuf.st_mode)) {
     struct NaClHostDir  *hd;
 
-    hd = malloc(sizeof *hd);
+    hd = malloc(sizeof(*hd));
     if (!hd) {
       retval = -NACL_ABI_ENOMEM;
       goto cleanup;
@@ -689,7 +689,7 @@ int32_t NaClSysOpen(struct NaClAppThread  *natp,
   } else {
     struct NaClHostDesc  *hd;
 
-    hd = malloc(sizeof *hd);
+    hd = malloc(sizeof(*hd));
     if (!hd) {
       retval = -NACL_ABI_ENOMEM;
       goto cleanup;
@@ -1086,7 +1086,7 @@ int32_t NaClSysLseek(struct NaClAppThread *natp,
     goto out;
   }
 
-  if (!NaClCopyInFromUser(nap, &offset, (uintptr_t) offp, sizeof offset)) {
+  if (!NaClCopyInFromUser(nap, &offset, (uintptr_t) offp, sizeof(offset))) {
     retval = -NACL_ABI_EFAULT;
     goto out_unref;
   }
@@ -1097,7 +1097,7 @@ int32_t NaClSysLseek(struct NaClAppThread *natp,
   if (NaClOff64IsNegErrno(&retval64)) {
     retval = (int32_t) retval64;
   } else {
-    if (NaClCopyOutToUser(nap, (uintptr_t) offp, &retval64, sizeof retval64)) {
+    if (NaClCopyOutToUser(nap, (uintptr_t) offp, &retval64, sizeof(retval64))) {
       retval = 0;
     } else {
       NaClLog(LOG_FATAL,
@@ -1195,7 +1195,7 @@ int32_t NaClSysFstat(struct NaClAppThread *natp,
            d, (uintptr_t)nasp);
 
   NaClLog(2, "sizeof(struct nacl_abi_stat) = %"NACL_PRIdS" (0x%"NACL_PRIxS")\n",
-          sizeof *nasp, sizeof *nasp);
+          sizeof(*nasp), sizeof(*nasp));
 
   fd = fd_cage_table[nap->cage_id][d];
 
@@ -1216,7 +1216,7 @@ int32_t NaClSysFstat(struct NaClAppThread *natp,
             Fstat)(ndp, &result);
   if (!retval) {
     if (!NaClCopyOutToUser(nap, (uintptr_t) nasp,
-                           &result, sizeof result)) {
+                           &result, sizeof(result))) {
       retval = -NACL_ABI_EFAULT;
     }
   }
@@ -1238,7 +1238,7 @@ int32_t NaClSysStat(struct NaClAppThread  *natp,
            " 0x%08"NACL_PRIxPTR")\n",
           (uintptr_t)natp,(uintptr_t)pathname, (uintptr_t)buf);
 
-  retval = CopyPathFromUser(nap, path, sizeof path, (uintptr_t) pathname);
+  retval = CopyPathFromUser(nap, path, sizeof(path), (uintptr_t) pathname);
   if (retval) {
     goto cleanup;
   }
@@ -1258,7 +1258,7 @@ int32_t NaClSysStat(struct NaClAppThread  *natp,
     retval = NaClAbiStatHostDescStatXlateCtor(&abi_stbuf,
                                               &stbuf);
     if (!NaClCopyOutToUser(nap, (uintptr_t) buf,
-                           &abi_stbuf, sizeof abi_stbuf)) {
+                           &abi_stbuf, sizeof(abi_stbuf))) {
       retval = -NACL_ABI_EFAULT;
     }
   }
@@ -1278,7 +1278,7 @@ int32_t NaClSysMkdir(struct NaClAppThread *natp,
     goto cleanup;
   }
 
-  retval = CopyPathFromUser(nap, path, sizeof path, pathname);
+  retval = CopyPathFromUser(nap, path, sizeof(path), pathname);
   if (retval) {
     goto cleanup;
   }
@@ -1299,7 +1299,7 @@ int32_t NaClSysRmdir(struct NaClAppThread *natp,
     goto cleanup;
   }
 
-  retval = CopyPathFromUser(nap, path, sizeof path, pathname);
+  retval = CopyPathFromUser(nap, path, sizeof(path), pathname);
   if (retval) {
     goto cleanup;
   }
@@ -1320,7 +1320,7 @@ int32_t NaClSysChdir(struct NaClAppThread *natp,
     goto cleanup;
   }
 
-  retval = CopyPathFromUser(nap, path, sizeof path, pathname);
+  retval = CopyPathFromUser(nap, path, sizeof(path), pathname);
   if (retval) {
     goto cleanup;
   }
@@ -1370,7 +1370,7 @@ int32_t NaClSysUnlink(struct NaClAppThread *natp,
     goto cleanup;
   }
 
-  retval = CopyPathFromUser(nap, path, sizeof path, pathname);
+  retval = CopyPathFromUser(nap, path, sizeof(path), pathname);
   if (retval) {
     goto cleanup;
   }
@@ -2223,7 +2223,7 @@ int32_t NaClSysMmap(struct NaClAppThread  *natp,
     return -NACL_ABI_EINVAL;
   }
 
-  sysaddr = NaClUserToSysAddrRange(nap, (uintptr_t)offp, sizeof offset);
+  sysaddr = NaClUserToSysAddrRange(nap, (uintptr_t)offp, sizeof(offset));
   if (kNaClBadAddress == sysaddr) {
     NaClLog(2, "%s\n", "NaClSysMmap: offset in a bad untrusted memory location");
     retval = -NACL_ABI_EFAULT;
@@ -2568,7 +2568,7 @@ int32_t NaClSysImcMakeBoundSock(struct NaClAppThread *natp,
   usr_pair[0] = NaClSetAvail(nap, pair[0]);
   usr_pair[1] = NaClSetAvail(nap, pair[1]);
   if (!NaClCopyOutToUser(nap, (uintptr_t) sap,
-                         usr_pair, sizeof usr_pair)) {
+                         usr_pair, sizeof(usr_pair))) {
     /*
      * NB: The descriptors were briefly observable to untrusted code
      * in this window, even though the syscall had not returned yet,
@@ -2672,7 +2672,7 @@ int32_t NaClSysImcSendmsg(struct NaClAppThread         *natp,
            (uintptr_t)natp, d, (uintptr_t)nanimhp, flags);
 
   if (!NaClCopyInFromUser(nap, &kern_nanimh, (uintptr_t) nanimhp,
-                          sizeof kern_nanimh)) {
+                          sizeof(kern_nanimh))) {
     NaClLog(2, "%s\n", "NaClImcMsgHdr not in user address space");
     retval = -NACL_ABI_EFAULT;
     goto cleanup_leave;
@@ -2702,7 +2702,7 @@ int32_t NaClSysImcSendmsg(struct NaClAppThread         *natp,
 
   if (kern_nanimh.iov_length > 0) {
     if (!NaClCopyInFromUser(nap, kern_naiov, (uintptr_t)kern_nanimh.iov,
-                            (kern_nanimh.iov_length * sizeof kern_naiov[0]))) {
+                            (kern_nanimh.iov_length * sizeof(kern_naiov[0])))) {
       NaClLog(2, "%s\n", "gather/scatter array not in user address space");
       retval = -NACL_ABI_EFAULT;
       goto cleanup_leave;
@@ -2731,7 +2731,7 @@ int32_t NaClSysImcSendmsg(struct NaClAppThread         *natp,
   /*
    * make things easier for cleaup exit processing
    */
-  memset(kern_desc, 0, sizeof kern_desc);
+  memset(kern_desc, 0, sizeof(kern_desc));
 
   kern_msg_hdr.iov = kern_iov;
   kern_msg_hdr.iov_length = kern_nanimh.iov_length;
@@ -2741,7 +2741,7 @@ int32_t NaClSysImcSendmsg(struct NaClAppThread         *natp,
     kern_msg_hdr.ndesc_length = 0;
   } else {
     if (!NaClCopyInFromUser(nap, usr_desc, kern_nanimh.descv,
-                            kern_nanimh.desc_length * sizeof usr_desc[0])) {
+                            kern_nanimh.desc_length * sizeof(usr_desc[0]))) {
       retval = -NACL_ABI_EFAULT;
       goto cleanup;
     }
@@ -2848,7 +2848,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
    * allocating a receive buffer.
    */
   if (!NaClCopyInFromUser(nap, &kern_nanimh, (uintptr_t) nanimhp,
-                          sizeof kern_nanimh)) {
+                          sizeof(kern_nanimh))) {
     NaClLog(4, "NaClImcMsgHdr not in user address space\n");
     retval = -NACL_ABI_EFAULT;
     goto cleanup_leave;
@@ -2874,7 +2874,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
      * user->kernel address conversions on this snapshot.
      */
     if (!NaClCopyInFromUser(nap, kern_naiov, (uintptr_t) kern_nanimh.iov,
-                            (kern_nanimh.iov_length * sizeof kern_naiov[0]))) {
+                            (kern_nanimh.iov_length * sizeof(kern_naiov[0])))) {
       NaClLog(4, "gather/scatter array not in user address space\n");
       retval = -NACL_ABI_EFAULT;
       goto cleanup_leave;
@@ -2919,8 +2919,8 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
   recv_hdr.iov_length = kern_nanimh.iov_length;
 
   recv_hdr.ndescv = new_desc;
-  recv_hdr.ndesc_length = sizeof new_desc / sizeof *new_desc;
-  memset(new_desc, 0, sizeof new_desc);
+  recv_hdr.ndesc_length = sizeof(new_desc) / sizeof(*new_desc);
+  memset(new_desc, 0, sizeof(new_desc));
 
   recv_hdr.flags = 0;  /* just to make it obvious; IMC will clear it for us */
 
@@ -2991,7 +2991,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
   }
   if (num_user_desc &&
       !NaClCopyOutToUser(nap, (uintptr_t)kern_nanimh.descv, usr_desc,
-                         num_user_desc * sizeof usr_desc[0])) {
+                         num_user_desc * sizeof(usr_desc[0]))) {
     NaClLog(1, "NaClSysImcRecvMsg: in/out ptr (descv %"NACL_PRIxPTR
             ") became invalid at copyout?\n",
             (uintptr_t) kern_nanimh.descv);
@@ -2999,7 +2999,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
 
   kern_nanimh.desc_length = num_user_desc;
   if (!NaClCopyOutToUser(nap, (uintptr_t)nanimhp, &kern_nanimh,
-                         sizeof kern_nanimh)) {
+                         sizeof(kern_nanimh))) {
     NaClLog(1, "%s\n",
             "NaClSysImcRecvMsg: in/out ptr (iov) became"
             " invalid at copyout?");
@@ -3008,7 +3008,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
 cleanup:
   /* copy out updated desc count, flags */
   if (retval < 0) {
-    for (i = 0; i < sizeof new_desc / sizeof *new_desc; ++i) {
+    for (i = 0; i < sizeof(new_desc) / sizeof(*new_desc); ++i) {
       if (new_desc[i]) {
         NaClDescUnref(new_desc[i]);
         new_desc[i] = NULL;
@@ -3045,7 +3045,7 @@ int32_t NaClSysImcMemObjCreate(struct NaClAppThread  *natp,
     return -NACL_ABI_EINVAL;
   }
 
-  shmp = malloc(sizeof *shmp);
+  shmp = malloc(sizeof(*shmp));
   if (!shmp) {
     retval = -NACL_ABI_ENOMEM;
     goto cleanup;
@@ -3086,7 +3086,7 @@ int32_t NaClSysImcSocketPair(struct NaClAppThread *natp,
   usr_pair[1] = NaClSetAvail(nap, pair[1]);
 
   if (!NaClCopyOutToUser(nap, (uintptr_t) descs_out, usr_pair,
-                         sizeof usr_pair)) {
+                         sizeof(usr_pair))) {
     NaClSetDesc(nap, usr_pair[0], NULL);
     NaClSetDesc(nap, usr_pair[1], NULL);
     retval = -NACL_ABI_EFAULT;
@@ -3422,7 +3422,7 @@ int32_t NaClSysCondTimedWaitAbs(struct NaClAppThread     *natp,
            (uintptr_t)natp, cond_handle, mutex_handle, (uintptr_t)ts);
 
   if (!NaClCopyInFromUser(nap, &trusted_ts,
-                          (uintptr_t) ts, sizeof trusted_ts)) {
+                          (uintptr_t) ts, sizeof(trusted_ts))) {
     retval = -NACL_ABI_EFAULT;
     goto cleanup;
   }
@@ -3565,13 +3565,13 @@ int32_t NaClSysNanosleep(struct NaClAppThread     *natp,
 
   /* do the check before we sleep */
   if (rem && kNaClBadAddress ==
-      NaClUserToSysAddrRange(nap, (uintptr_t) rem, sizeof *rem)) {
+      NaClUserToSysAddrRange(nap, (uintptr_t) rem, sizeof(*rem))) {
     retval = -NACL_ABI_EFAULT;
     goto cleanup;
   }
 
   if (!NaClCopyInFromUser(nap, &t_sleep,
-                          (uintptr_t) req, sizeof t_sleep)) {
+                          (uintptr_t) req, sizeof(t_sleep))) {
     retval = -NACL_ABI_EFAULT;
     goto cleanup;
   }
@@ -3589,7 +3589,7 @@ int32_t NaClSysNanosleep(struct NaClAppThread     *natp,
   retval = NaClNanosleep(&t_sleep, remptr);
   NaClLog(2, "NaClNanosleep returned %d\n", retval);
 
-  if (-NACL_ABI_EINTR == retval && rem && !NaClCopyOutToUser(nap, (uintptr_t)rem, remptr, sizeof *remptr)) {
+  if (-NACL_ABI_EINTR == retval && rem && !NaClCopyOutToUser(nap, (uintptr_t)rem, remptr, sizeof(*remptr))) {
     NaClLog(1, "%s\n", "NaClSysNanosleep: check rem failed at copyout\n");
   }
 
@@ -3634,7 +3634,7 @@ int32_t NaClSysExceptionHandler(struct NaClAppThread *natp,
   if (old_handler &&
       !NaClCopyOutToUser(nap, (uintptr_t) old_handler,
                          &nap->exception_handler,
-                         sizeof nap->exception_handler)) {
+                         sizeof(nap->exception_handler))) {
     rv = -NACL_ABI_EFAULT;
     goto unlock_exit;
   }
@@ -3850,7 +3850,7 @@ int32_t NaClSysGetTimeOfDay(struct NaClAppThread      *natp,
 #endif
   CHECK(now.nacl_abi_tv_usec >= 0);
   CHECK(now.nacl_abi_tv_usec < NACL_MICROS_PER_UNIT);
-  if (!NaClCopyOutToUser(natp->nap, (uintptr_t)tv, &now, sizeof now)) {
+  if (!NaClCopyOutToUser(natp->nap, (uintptr_t)tv, &now, sizeof(now))) {
     return -NACL_ABI_EFAULT;
   }
   return 0;
@@ -3883,7 +3883,7 @@ int32_t NaClSysClockGetCommon(struct NaClAppThread  *natp,
     goto done;
   }
   retval = time_func((nacl_clockid_t) clk_id, &out_buf);
-  if (!retval && !NaClCopyOutToUser(nap, (uintptr_t)ts_addr, &out_buf, sizeof out_buf)) {
+  if (!retval && !NaClCopyOutToUser(nap, (uintptr_t)ts_addr, &out_buf, sizeof(out_buf))) {
     retval = -NACL_ABI_EFAULT;
   }
 
@@ -3950,7 +3950,7 @@ int32_t NaClSysPipe(struct NaClAppThread  *natp, uint32_t *pipedes) {
   }
 
   /* copy out sanitized fds */
-  if (!NaClCopyOutToUser(nap, (uintptr_t)pipedes, nacl_fds, sizeof nacl_fds)) {
+  if (!NaClCopyOutToUser(nap, (uintptr_t)pipedes, nacl_fds, sizeof(nacl_fds))) {
       ret = -NACL_ABI_EFAULT;
   }
 
@@ -4019,7 +4019,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, void *pathname, void *argv, vo
     for (char **pp = sys_envp; *pp; ++pp) {
       new_envc++;
     }
-    new_envp = calloc(new_envc + 1, sizeof *new_envp);
+    new_envp = calloc(new_envc + 1, sizeof(*new_envp));
     if (!new_envp) {
       NaClLog(LOG_ERROR, "%s\n", "Failed to allocate new_envv");
       NaClEnvCleanserDtor(&env_cleanser);
@@ -4051,7 +4051,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, void *pathname, void *argv, vo
   for (char **pp = sys_argv; *pp; ++pp) {
     new_argc++;
   }
-  new_argv = calloc(new_argc + 1, sizeof *new_argv);
+  new_argv = calloc(new_argc + 1, sizeof(*new_argv));
   if (!new_argv) {
     NaClLog(LOG_ERROR, "%s\n", "Failed to allocate new_argv");
     NaClEnvCleanserDtor(&env_cleanser);
@@ -4069,7 +4069,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, void *pathname, void *argv, vo
 
   /* set up new "child" NaClApp */
   child_argc = new_argc + 3;
-  child_argv = calloc(child_argc + 1, sizeof *child_argv);
+  child_argv = calloc(child_argc + 1, sizeof(*child_argv));
   if (!child_argv) {
     NaClLog(LOG_ERROR, "%s\n", "Failed to allocate child_argv");
     NaClEnvCleanserDtor(&env_cleanser);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -181,9 +181,7 @@ int32_t NaClSysBrk(struct NaClAppThread *natp,
     NaClLog(4, "last internal data addr 0x%08"NACL_PRIxPTR"\n",
             last_internal_data_addr);
 
-    if (NULL == NaClVmmapFindPageIter(&nap->mem_map,
-                                      usr_last_data_page,
-                                      &iter)
+    if (!NaClVmmapFindPageIter(&nap->mem_map, usr_last_data_page, &iter)
         || NaClVmmapIterAtEnd(&iter)) {
       NaClLog(LOG_FATAL, ("current break (0x%08"NACL_PRIxPTR", "
                           "sys 0x%08"NACL_PRIxPTR") "
@@ -2792,7 +2790,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
   recv_hdr.iov_length = kern_nanimh.iov_length;
 
   recv_hdr.ndescv = new_desc;
-  recv_hdr.ndesc_length = NACL_ARRAY_SIZE(new_desc);
+  recv_hdr.ndesc_length = sizeof new_desc / sizeof *new_desc;
   memset(new_desc, 0, sizeof new_desc);
 
   recv_hdr.flags = 0;  /* just to make it obvious; IMC will clear it for us */
@@ -2881,7 +2879,7 @@ int32_t NaClSysImcRecvmsg(struct NaClAppThread         *natp,
 cleanup:
   /* copy out updated desc count, flags */
   if (retval < 0) {
-    for (i = 0; i < NACL_ARRAY_SIZE(new_desc); ++i) {
+    for (i = 0; i < sizeof new_desc / sizeof *new_desc; ++i) {
       if (new_desc[i]) {
         NaClDescUnref(new_desc[i]);
         new_desc[i] = NULL;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -348,6 +348,21 @@ int32_t NaClSysGetpid(struct NaClAppThread *natp) {
   return pid;
 }
 
+int32_t NaClSysGetppid(struct NaClAppThread *natp) {
+  int32_t ppid;
+  struct NaClApp *nap = natp->nap;
+
+  if (!nap->parent) {
+    ppid = 0;
+    goto out;
+  }
+  ppid = nap->parent->cage_id;
+
+out:
+  NaClLog(1, "NaClSysGetpid: returning %d\n", ppid);
+  return ppid;
+}
+
 int32_t NaClSysExit(struct NaClAppThread  *natp,
                     int                   status) {
   struct NaClApp *nap = natp->nap;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -539,9 +539,6 @@ int32_t NaClSysDup3(struct NaClAppThread  *natp,
                     int                   newfd,
                     int                   flags) {
   struct NaClApp *nap = natp->nap;
-  struct NaClDesc *old_nd;
-  int old_desc;
-  int new_desc;
   int ret;
 
   NaClLog(1, "%s\n", "[dup3] Entered dup3!");
@@ -549,41 +546,14 @@ int32_t NaClSysDup3(struct NaClAppThread  *natp,
   NaClLog(1, "[dup3] oldfd = %d \n", oldfd);
   NaClLog(1, "[dup3] newfd = %d \n", newfd);
 
+  UNREFERENCED_PARAMETER(nap);
+  UNREFERENCED_PARAMETER(ret);
   /*
-   * TODO: implement flags -jp
+   * TODO: implement dup3 flags -jp
    */
   UNREFERENCED_PARAMETER(flags);
 
-  /* check for closed fds */
-  if (oldfd < 0) {
-    ret = -NACL_ABI_EBADF;
-    goto out;
-  }
-
-  if (oldfd == newfd) {
-    ret = -NACL_ABI_EINVAL;
-    goto out;
-  }
-  if (nap->fd++ > FILE_DESC_MAX) {
-    ret = -NACL_ABI_EBADF;
-    goto out;
-  }
-  old_desc = fd_cage_table[nap->cage_id][oldfd];
-  if (!(old_nd = NaClGetDesc(nap, old_desc))) {
-    ret= -NACL_ABI_EBADF;
-    goto out;
-  }
-  if (fd_cage_table[nap->cage_id][newfd]) {
-    NaClSysClose(natp, newfd);
-  }
-  new_desc = NaClSetAvail(nap, old_nd);
-  NaClSetDesc(nap, new_desc, old_nd);
-  fd_cage_table[nap->cage_id][newfd] = new_desc;
-  nap->fd = newfd;
-  ret = nap->fd++;
-
-out:
-  return ret;
+  return NaClSysDup2(natp, oldfd, newfd);
 }
 
 static uint32_t CopyPathFromUser(struct NaClApp *nap,

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -520,7 +520,11 @@ int32_t NaClSysDup2(struct NaClAppThread  *natp,
     ret= -NACL_ABI_EBADF;
     goto out;
   }
+  if (fd_cage_table[nap->cage_id][newfd]) {
+    NaClSysClose(natp, newfd);
+  }
   new_desc = NaClSetAvail(nap, old_nd);
+  NaClSetDesc(nap, new_desc, old_nd);
   fd_cage_table[nap->cage_id][newfd] = new_desc;
   nap->fd = newfd;
   ret = nap->fd++;
@@ -568,7 +572,11 @@ int32_t NaClSysDup3(struct NaClAppThread  *natp,
     ret= -NACL_ABI_EBADF;
     goto out;
   }
+  if (fd_cage_table[nap->cage_id][newfd]) {
+    NaClSysClose(natp, newfd);
+  }
   new_desc = NaClSetAvail(nap, old_nd);
+  NaClSetDesc(nap, new_desc, old_nd);
   fd_cage_table[nap->cage_id][newfd] = new_desc;
   nap->fd = newfd;
   ret = nap->fd++;

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -26,6 +26,7 @@ struct NaClSocketAddress;
 struct NaClDesc;
 struct NaClImcMsgHdr;
 struct nacl_abi_stat;
+struct rusage;
 
 int32_t NaClSysNotImplementedDecoder(struct NaClAppThread *natp);
 
@@ -47,6 +48,7 @@ int32_t NaClStatAclCheck(struct NaClApp *nap,
                          char const     *path);
 
 int32_t NaClSysGetpid(struct NaClAppThread *natp);
+int32_t NaClSysGetppid(struct NaClAppThread *natp);
 
 int32_t NaClSysExit(struct NaClAppThread  *natp,
                     int                   status);
@@ -106,7 +108,7 @@ int32_t NaClSysFstat(struct NaClAppThread *natp,
                      struct nacl_abi_stat *nasp);
 
 int32_t NaClSysStat(struct NaClAppThread *natp,
-                    const char           *path,
+                    const char           *pathname,
                     struct nacl_abi_stat *nasp);
 
 int32_t NaClSysMkdir(struct NaClAppThread *natp,
@@ -217,7 +219,7 @@ int32_t NaClSysTlsInit(struct NaClAppThread  *natp,
                        uint32_t              thread_ptr);
 
 int32_t NaClSysThreadCreate(struct NaClAppThread *natp,
-                            void                 *eip,
+                            void                 *prog_ctr,
                             uint32_t             stack_ptr,
                             uint32_t             thread_ptr,
                             uint32_t             second_thread_ptr);
@@ -306,13 +308,15 @@ int32_t NaClSysTestInfoLeak(struct NaClAppThread *natp);
 
 int32_t NaClSysTestCrash(struct NaClAppThread *natp, int crash_type);
 
-int32_t NaClSysPipe(struct NaClAppThread  *natp, uint32_t *pipedes);
-int32_t NaClSysFork(struct NaClAppThread  *natp);
-int32_t NaClSysExecv(struct NaClAppThread  *natp);
-int32_t NaClSysExecve(struct NaClAppThread  *natp, void *path, void *argv, void *envp);
-int32_t NaClSysWaitpid(struct NaClAppThread  *natp, uint32_t pid, uint32_t *stat_loc, uint32_t options);
-
-int32_t NaClSysWait(struct NaClAppThread  *natp, uint32_t *stat_loc);
+int32_t NaClSysPipe(struct NaClAppThread *natp, uint32_t *pipedes);
+int32_t NaClSysPipe2(struct NaClAppThread *natp, uint32_t *pipedes, int flags);
+int32_t NaClSysFork(struct NaClAppThread *natp);
+int32_t NaClSysExecve(struct NaClAppThread *natp, void* pathname, void* argv, void* envp);
+int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv);
+int32_t NaClSysWaitpid(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options);
+int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc);
+int32_t NaClSysWait4(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options, void *rusage);
+int32_t NaClSysSigProcMask(struct NaClAppThread *natp, int how, const void *set, void *oldset);
 
 EXTERN_C_END
 

--- a/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
+++ b/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
@@ -244,12 +244,16 @@ SYSCALL_LIST = [
     ('NACL_sys_test_infoleak', 'NaClSysTestInfoLeak', []),
     ('NACL_sys_test_crash', 'NaClSysTestCrash', ['int crash_type']),
     ('NACL_sys_lind_syscall', 'NaClSysLindSyscall', ['uint32_t callNum', 'uint32_t inNum', 'void *inArgs', 'uint32_t outNum', 'void *outArgs']),
-    ('NACL_sys_pipe', 'NaClSysPipe', ['uint32_t *pipedes']),
     ('NACL_sys_fork', 'NaClSysFork', []),
-    ('NACL_sys_execv', 'NaClSysExecv', []),
+    ('NACL_sys_execv', 'NaClSysExecv', ['void *path', 'void *argv']),
     ('NACL_sys_execve', 'NaClSysExecve', ['void *path', 'void *argv', 'void *envp']),
-    ('NACL_sys_waitpid', 'NaClSysWaitpid', ['uint32_t pid', 'uint32_t *stat_loc', 'uint32_t options']),
+    ('NACL_sys_pipe', 'NaClSysPipe', ['uint32_t *pipedes']),
+    ('NACL_sys_pipe2', 'NaClSysPipe2', ['uint32_t *pipedes', 'int flags']),
+    ('NACL_sys_getppid', 'NaClSysGetppid', []),
+    ('NACL_sys_waitpid', 'NaClSysWaitpid', ['int pid', 'uint32_t *stat_loc', 'int options']),
     ('NACL_sys_wait', 'NaClSysWait', ['uint32_t *stat_loc']),
+    ('NACL_sys_wait4', 'NaClSysWait4', ['int pid', 'uint32_t *stat_loc', 'int options', 'void *rusage']),
+    ('NACL_sys_sigprocmask', 'NaClSysSigProcMask', ['int how', 'const void *set', 'void *oldset']),
     ]
 
 

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -189,6 +189,8 @@ int NaClAppWithSyscallTableCtor(struct NaClApp               *nap,
   nap->secure_service = NULL;
   nap->irt_loaded = 0;
   nap->main_exe_prevalidated = 0;
+  nap->manifest_proxy = NULL;
+  nap->kernel_service = NULL;
   nap->resource_phase = NACL_RESOURCE_PHASE_START;
 
   if (!NaClResourceNaClAppInit(&nap->resources, nap)) {

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -376,7 +376,7 @@ static void NaClStoreMem(uintptr_t  addr,
 
   CHECK(nbytes <= 8);
 
-  for (i = 0; i < nbytes; ++i) {
+  for (i = 0; i < nbytes; i++) {
     ((uint8_t *) addr)[i] = (uint8_t) value;
     value = value >> 8;
   }
@@ -416,25 +416,25 @@ void  NaClApplyPatchToMemory(struct NaClPatchInfo  *patch) {
   reloc = patch->dst - patch->src;
 
 
-  for (i = 0; i < patch->num_abs64; ++i) {
+  for (i = 0; i < patch->num_abs64; i++) {
     offset = patch->abs64[i].target - patch->src;
     target_addr = patch->dst + offset;
     NaClStore64(target_addr, patch->abs64[i].value);
   }
 
-  for (i = 0; i < patch->num_abs32; ++i) {
+  for (i = 0; i < patch->num_abs32; i++) {
     offset = patch->abs32[i].target - patch->src;
     target_addr = patch->dst + offset;
     NaClStore32(target_addr, (uint32_t) patch->abs32[i].value);
   }
 
-  for (i = 0; i < patch->num_abs16; ++i) {
+  for (i = 0; i < patch->num_abs16; i++) {
     offset = patch->abs16[i].target - patch->src;
     target_addr = patch->dst + offset;
     NaClStore16(target_addr, (uint16_t) patch->abs16[i].value);
   }
 
-  for (i = 0; i < patch->num_rel64; ++i) {
+  for (i = 0; i < patch->num_rel64; i++) {
     offset = patch->rel64[i] - patch->src;
     target_addr = patch->dst + offset;
     NaClStore64(target_addr, NaClLoad64(target_addr) - reloc);
@@ -451,7 +451,7 @@ void  NaClApplyPatchToMemory(struct NaClPatchInfo  *patch) {
    * expensive way to save a few bytes per reloc.
    */
 #if NACL_TARGET_SUBARCH == 32
-  for (i = 0; i < patch->num_rel32; ++i) {
+  for (i = 0; i < patch->num_rel32; i++) {
     offset = patch->rel32[i] - patch->src;
     target_addr = patch->dst + offset;
     NaClStore32(target_addr,

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -82,9 +82,8 @@ struct NaClValidationMetadata;
 
 struct Pipe {
   bool xfer_done;
-  unsigned char pipe_buf[PIPE_BUF_MAX];
-  struct NaClMutex mu;
-  struct NaClCondVar cv;
+  bool is_closed;
+  struct NaClFastMutex mu;
 };
 
 extern volatile sig_atomic_t fork_num;
@@ -146,11 +145,13 @@ struct NaClApp {
   volatile sig_atomic_t     num_lib;
   volatile sig_atomic_t     parent_id;
 
-  // yiwen: store the path of the execuable running inside this cage(as the main thread)
-  int                       command_num;
-  char                      *binary_path;
-  char                      *binary_command;
+  /* yiwen: store the path of the execuable running inside this cage(as the main thread) */
+  int                       argc;
+  char                      **argv;
+  char                      *binary;
   char                      *nacl_file;
+  char const *const         *clean_environ;
+  volatile int              in_fork;
   /* set to the next unused (available for dup() etc.) file descriptor */
   int                       fd;
 

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -725,11 +725,11 @@ int NaClCreateMainThread(struct NaClApp     *nap,
    * data.  We are assuming that the caller is non-adversarial and the
    * code does not look like string data....
    */
-  for (i = 0; i < argc && argv && argv[i]; ++i) {
+  for (i = 0; i < argc && argv && argv[i]; i++) {
     argv_len[i] = strlen(argv[i]) + 1;
     size += argv_len[i];
   }
-  for (i = 0; i < envc && envv && envv[i]; ++i) {
+  for (i = 0; i < envc && envv && envv[i]; i++) {
     envv_len[i] = strlen(envv[i]) + 1;
     size += envv_len[i];
   }
@@ -803,7 +803,7 @@ int NaClCreateMainThread(struct NaClApp     *nap,
   *p++ = envc;
   *p++ = argc;
 
-  for (i = 0; i < argc && argv && argv[i]; ++i) {
+  for (i = 0; i < argc && argv && argv[i]; i++) {
     *p++ = (uint32_t) NaClSysToUser(nap, (uintptr_t)strp);
     NaClLog(2, "copying arg %d  %p -> %p\n",
             i, (void *)argv[i], (void *)strp);
@@ -812,7 +812,7 @@ int NaClCreateMainThread(struct NaClApp     *nap,
   }
   *p++ = 0;  /* argv[argc] is NULL.  */
 
-  for (i = 0; i < envc && envv && envv[i]; ++i) {
+  for (i = 0; i < envc && envv && envv[i]; i++) {
     *p++ = (uint32_t) NaClSysToUser(nap, (uintptr_t)strp);
     NaClLog(1, "copying env %d  %p -> %p\n",
             i, (void *)envv[i], (void *)strp);
@@ -937,11 +937,11 @@ int NaClCreateMainForkThread(struct NaClApp           *nap_parent,
    * data.  We are assuming that the caller is non-adversarial and the
    * code does not look like string data....
    */
-  for (i = 0; i < argc && argv; ++i) {
+  for (i = 0; i < argc && argv; i++) {
     argv_len[i] = strlen(argv[i]) + 1;
     size += argv_len[i];
   }
-  for (i = 0; i < envc; ++i) {
+  for (i = 0; i < envc; i++) {
     envv_len[i] = strlen(envv[i]) + 1;
     size += envv_len[i];
   }
@@ -1022,7 +1022,7 @@ int NaClCreateMainForkThread(struct NaClApp           *nap_parent,
   *p++ = envc;
   *p++ = argc;
 
-  for (i = 0; i < argc && argv && argv[i]; ++i) {
+  for (i = 0; i < argc && argv && argv[i]; i++) {
     *p++ = (uint32_t) NaClSysToUser(nap_child, (uintptr_t)strp);
     NaClLog(1, "copying arg %d  %p -> %p\n",
             i, (void *)argv[i], (void *)strp);
@@ -1031,7 +1031,7 @@ int NaClCreateMainForkThread(struct NaClApp           *nap_parent,
   }
   *p++ = 0;  /* argv[argc] is NULL.  */
 
-  for (i = 0; i < envc && envv && envv[i]; ++i) {
+  for (i = 0; i < envc && envv && envv[i]; i++) {
     *p++ = (uint32_t) NaClSysToUser(nap_child, (uintptr_t)strp);
     NaClLog(1, "copying env %d  %p -> %p\n",
             i, (void *)envv[i], (void *)strp);


### PR DESCRIPTION
Add `execv()` and `execve()` system call implementations to the internal runtime.

Implementation Details:
- Copy the argument and environment vectors from the "parent" NaClApp.
- Duplicate its `cage_id` along with any other relevant internal state.
- Leverage the existing fork() implementation to emulate replacement of the entire process image.