### PR TITLE
Add working Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,14 +17,15 @@ matrix:
             - g++-multilib
 
 script:
-    # special case pull requests so they build the source and not the target branch
-    - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then cur_branch="$TRAVIS_BRANCH"; else cur_branch="$TRAVIS_PULL_REQUEST_BRANCH"; fi
-    # skip building the master and lind branches as those don't exist in all subrepositories
-    #
-    # TODO: make subrepository branch names consistent and remove special casing of master and lind -jp
-    - if [[ "$cur_branch" == master || "$cur_branch" == lind ]]; then cur_branch="develop"; fi
-    # run a test of the loader after building
-    - docker build --build-arg=BRANCH="$cur_branch" -t alyptik/lind .
-    - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind lind /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched; exec /fork"'
+  # special case pull requests so they build the source and not the target branch
+  - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then cur_branch="$TRAVIS_BRANCH"; else cur_branch="$TRAVIS_PULL_REQUEST_BRANCH"; fi
+  # skip building the master and lind branches as those don't exist in all subrepositories
+  #
+  # TODO: make subrepository branch names consistent and remove special casing of master and lind -jp
+  - if [[ "$cur_branch" == master || "$cur_branch" == lind ]]; then cur_branch="develop"; fi
+  # travis_wait needed due to build log exceeding Travis CI's maximum length
+  - travis_wait 60 bash -c "docker build --build-arg=BRANCH=$cur_branch -t alyptik/lind . >/dev/null 2>&1"
+  # run a test of the loader after building
+  - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind lind /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched; exec /fork"'
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
     # be examined manually.
     #
     # TODO: modify loader to only return non-zero on errors -jp
-    - docker build -t alyptik/lind:naclruntime .
+    - docker build --build-arg=TRAVIS_COMMIT="$TRAVIS_COMMIT" -t alyptik/lind:naclruntime .
     - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' || true
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,8 @@ script:
     # be examined manually.
     #
     # TODO: modify loader to only return non-zero on errors -jp
-    - docker build --build-arg=TRAVIS_COMMIT="$TRAVIS_COMMIT" -t alyptik/lind:naclruntime .
+    - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then BRANCH="$TRAVIS_BRANCH"; else BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"; fi
+    - docker build --build-arg=BRANCH="$BRANCH" -t alyptik/lind:naclruntime .
     - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' || true
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: trusty
 group: deprecated-2017Q4
 sudo: required
-env:
-  - REPY_PATH="/home/lind/lind_project/lind/repy"
 services:
   - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,14 +2,18 @@ dist: trusty
 language: c
 group: deprecated-2017Q4
 sudo: required
+
+env:
+  - REPY_PATH="/home/lind/lind_project/lind/repy"
+
 services:
   - docker
+
 git:
     depth: 1
 
 matrix:
   include:
-    # works on Precise and Trusty
     - os: linux
       addons:
         apt:
@@ -21,7 +25,15 @@ matrix:
             - g++-multilib
 
 script:
+    # Run a test of the loader after building. Since the loader always
+    # returns non-zerom even if there were no errors, the results must
+    # be examined manually.
+    #
+    # TODO: modify loader to only return non-zero on errors -jp
     - docker build -t alyptik/lind:naclruntime .
-    - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime /home/lind/lind_project/lind/repy/bin/lind /bin/bash -c 'a=potato; [[ $a =~ pota.* ]] && echo foo; echo bar' || true
+    - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime \
+      /home/lind/lind_project/lind/repy/bin/lind \
+      /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' \
+      || true
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ dist: trusty
 language: c
 group: deprecated-2017Q4
 sudo: required
-
+git:
+  submodules: false
 env:
   - REPY_PATH="/home/lind/lind_project/lind/repy"
-
 services:
   - docker
 
@@ -22,13 +22,14 @@ matrix:
             - g++-multilib
 
 script:
-    # Run a test of the loader after building. Since the loader always
-    # returns non-zerom even if there were no errors, the results must
-    # be examined manually.
+    # special case pull requests so they build the source and not the target branch
+    - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then cur_branch="$TRAVIS_BRANCH"; else cur_branch="$TRAVIS_PULL_REQUEST_BRANCH"; fi
+    # skip building the master and lind branches as those don't exist in all subrepositories
     #
-    # TODO: modify loader to only return non-zero on errors -jp
-    - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then BRANCH="$TRAVIS_BRANCH"; else BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"; fi
-    - docker build --build-arg=BRANCH="$BRANCH" -t alyptik/lind:naclruntime .
-    - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' || true
+    # TODO: make subrepository branch names consistent and remove special casing of master and lind -jp
+    - if [[ "$cur_branch" == master || "$cur_branch" == lind ]]; then cur_branch="develop"; fi
+    # run a test of the loader after building
+    - docker build --build-arg=BRANCH="$cur_branch" -t alyptik/lind .
+    - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched; exec /fork"'
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,6 @@ script:
     #
     # TODO: modify loader to only return non-zero on errors -jp
     - docker build -t alyptik/lind:naclruntime .
-    - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime \
-      /home/lind/lind_project/lind/repy/bin/lind \
-      /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' \
-      || true
+    - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' || true
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+dist: trusty
+language: c
+group: deprecated-2017Q4
+sudo: required
+services:
+  - docker
+git:
+    depth: 1
+git:
+  submodules: false
+
+matrix:
+  include:
+    # works on Precise and Trusty
+    - os: linux
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - build-essential
+            - gcc-multilib
+            - g++-multilib
+
+before_install:
+    - git submodule update --init --recursive --remote .
+
+script:
+    - docker build -t alyptik/lind:naclruntime .
+    - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime /home/lind/lind_project/lind/repy/bin/lind /bin/bash -c 'a=potato; [[ $a =~ pota.* ]] && echo foo; echo bar' || true
+
+# vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ services:
   - docker
 git:
     depth: 1
-git:
-  submodules: false
 
 matrix:
   include:
@@ -21,9 +19,6 @@ matrix:
             - build-essential
             - gcc-multilib
             - g++-multilib
-
-before_install:
-    - git submodule update --init --recursive --remote .
 
 script:
     - docker build -t alyptik/lind:naclruntime .

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 dist: trusty
-language: c
 group: deprecated-2017Q4
 sudo: required
-git:
-  submodules: false
 env:
   - REPY_PATH="/home/lind/lind_project/lind/repy"
 services:
@@ -30,6 +27,6 @@ script:
     - if [[ "$cur_branch" == master || "$cur_branch" == lind ]]; then cur_branch="develop"; fi
     # run a test of the loader after building
     - docker build --build-arg=BRANCH="$cur_branch" -t alyptik/lind .
-    - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched; exec /fork"'
+    - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind lind /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched; exec /fork"'
 
 # vi:ft=yaml:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,6 @@ env:
 services:
   - docker
 
-git:
-    depth: 1
-
 matrix:
   include:
     - os: linux
@@ -32,6 +29,6 @@ script:
     # TODO: modify loader to only return non-zero on errors -jp
     - if [[ "$TRAVIS_PULL_REQUEST" == false ]]; then BRANCH="$TRAVIS_BRANCH"; else BRANCH="$TRAVIS_PULL_REQUEST_BRANCH"; fi
     - docker build --build-arg=BRANCH="$BRANCH" -t alyptik/lind:naclruntime .
-    - docker run --rm --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' || true
+    - docker run --ipc=host --cap-add=SYS_PTRACE -it alyptik/lind:naclruntime "$REPY_PATH/bin/lind" /bin/bash -c 'a="regex_test_string"; [[ $a =~ reg.*ng$ ]] && echo "string matched"' || true
 
 # vi:ft=yaml:

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ ARG BRANCH
 
 ENV PATH "/root/bin:/home/lind/bin:$PATH"
 ENV PATH "/root/.local/bin:/home/lind/.local/bin:$PATH"
-ENV PATH "/home/lind/lind_project/lind/repy/bin:$PATH"
 ENV PATH "/home/lind/lind_project:$PATH"
+ENV PATH "/home/lind/lind_project/lind/repy/bin:$PATH"
+ENV PATH "/home/lind/lind_project/lind/repy/sdk/toolchain/linux_x86_glibc/bin:$PATH"
 
 USER lind
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN git submodule update --recursive --remote .
 RUn for t in nacl repy install; do ./mklind -q "$t"; done
-RUN env x86_64-nacl-gcc test_cases/fork.c -o lind/repy/repy/fork
-RUN env x86_64-nacl-gcc test_cases/hello.c -o lind/repy/repy/hello
+RUn for t in nacl repy install; do ./mklind -q "$t"; done
+RUN x86_64-nacl-gcc "test_cases/fork.c" -o "lind/repy/repy/fork"
+RUN x86_64-nacl-gcc "test_cases/hello.c" -o "lind/repy/repy/hello"
 WORKDIR /home/lind/lind_project/test_cases/bash/
 RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
 RUN make install

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL description "Lind NaCl Runtime (Pre-built)"
 MAINTAINER Joey Pabalinas <joeypabalinas@gmail.com>
 
 # defaults to develop
-ARG TRAVIS_COMMIT
+ARG BRANCH
 
 ENV LIND_PREFIX "/home/lind"
 ENV LIND_BASE "$LIND_PREFIX/lind_project"

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV PATH "/root/.local/bin:/home/lind/.local/bin:$PATH"
 USER lind
 
 WORKDIR /home/lind/lind_project/
+RUN ["/usr/bin/git", "pull", "-t", "-j8"]
+RUN ["/usr/bin/git", "submodule", "update", "--recursive", "--remote", "."]
 RUN ["./mklind", "-qe", "nacl"]
 RUN ["./mklind", "-qe", "repy"]
 RUN ["./mklind", "-qe", "install"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ LABEL lind "v1.0-rc4"
 LABEL description "Lind NaCl Runtime (Pre-built)"
 MAINTAINER Joey Pabalinas <joeypabalinas@gmail.com>
 
+# defaults to develop
+ARG TRAVIS_COMMIT
+
 ENV LIND_PREFIX "/home/lind"
 ENV LIND_BASE "$LIND_PREFIX/lind_project"
 ENV LIND_SRC "$LIND_BASE/lind"
@@ -45,4 +48,5 @@ RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /fork)", "/dev/null"
 RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /hello)", "/dev/null"]
 RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /bin/bash --version)", "/dev/null"]
 
+# default to running test cases then a shell if no arguments are passed to `docker run`
 CMD ["/usr/bin/bash", "-c", "lind /fork; lind /hello; lind /bin/bash --version; exec bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,52 +1,41 @@
 FROM alyptik/lind:prebuiltsdk
-LABEL lind "v1.0-rc4"
+LABEL lind "v1.0-rc5"
 LABEL description "Lind NaCl Runtime (Pre-built)"
 MAINTAINER Joey Pabalinas <joeypabalinas@gmail.com>
 
 ARG BRANCH
-ENV BRANCH "${BRANCH:-develop}"
 
-ENV LIND_PREFIX "/home/lind"
-ENV LIND_BASE "$LIND_PREFIX/lind_project"
-ENV LIND_SRC "$LIND_BASE/lind"
-ENV LIND_MONITOR "$LIND_BASE/reference_monitor"
-ENV REPY_PATH "$LIND_SRC/repy"
-ENV NACL_SDK_ROOT "$REPY_PATH/sdk"
-ENV PYTHON "python2"
-ENV PNACLPYTHON "python2"
-ENV LD_LIBRARY_PATH "/lib/glibc"
-ENV PATH "$NACL_SDK_ROOT/toolchain/linux_x86_glibc/bin:$PATH"
-ENV PATH "$REPY_PATH/bin:$PATH"
-ENV PATH "$LIND_BASE:$PATH"
 ENV PATH "/root/bin:/home/lind/bin:$PATH"
 ENV PATH "/root/.local/bin:/home/lind/.local/bin:$PATH"
+ENV PATH "/home/lind/lind_project/lind/repy/bin:$PATH"
+ENV PATH "/home/lind/lind_project:$PATH"
 
 USER lind
 
 WORKDIR /home/lind/lind_project/
-RUN ["/usr/bin/git", "pull", "-t", "-j8"]
-RUN ["/usr/bin/git", "submodule", "update", "--recursive", "--remote", "."]
-RUN ["./mklind", "-qe", "nacl"]
-RUN ["./mklind", "-qe", "repy"]
-RUN ["./mklind", "-qe", "install"]
-RUN ["/usr/bin/env", "x86_64-nacl-gcc", "test_cases/fork.c", "-o", "lind/repy/repy/fork"]
-RUN ["/usr/bin/env", "x86_64-nacl-gcc", "test_cases/hello.c", "-o", "lind/repy/repy/hello"]
+RUN git pull -t -j8
+RUN git submodule update --recursive --remote .
+RUN ./mklind -q nacl
+RUN ./mklind -q repy
+RUN ./mklind -q install
+RUN x86_64-nacl-gcc test_cases/fork.c -o lind/repy/repy/fork
+RUN x86_64-nacl-gcc test_cases/hello.c -o lind/repy/repy/hello
 WORKDIR /home/lind/lind_project/test_cases/bash/
-RUN ["./bootstrap_nacl", "--prefix=/home/lind/lind_project/lind/repy/repy"]
-RUN ["/usr/bin/make", "install"]
+RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
+RUN make install
 
 WORKDIR /home/lind/lind_project/lind/repy/repy/
-RUN ["/usr/bin/env", "lindfs", "cp", "./bin/"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./lib/"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./share/"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./fork"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./hello"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./.bashrc"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./.bash_logout"]
-RUN ["/usr/bin/env", "lindfs", "cp", "./.bash_profile"]
-RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /fork)", "/dev/null"]
-RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /hello)", "/dev/null"]
-RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /bin/bash --version)", "/dev/null"]
+RUN lindfs cp ./bin/
+RUN lindfs cp ./lib/
+RUN lindfs cp ./share/
+RUN lindfs cp ./fork
+RUN lindfs cp ./hello
+RUN lindfs cp ./.bashrc
+RUN lindfs cp ./.bash_logout
+RUN lindfs cp ./.bash_profile
+RUN script -qfc "$(printf '%q ' lind /fork)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /hello)" /dev/null
+RUN script -qfc "$(printf '%q ' lind /bin/bash --version)" /dev/null
 
 # default to running test cases then a shell if no arguments are passed to `docker run`
-CMD ["/usr/bin/bash", "-c", "lind /fork; lind /hello; lind /bin/bash --version; exec bash"]
+CMD bash -c 'lind /fork; lind /hello; lind /bin/bash --version; exec bash'

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,5 +43,4 @@ RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /fork)", "/dev/null"
 RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /hello)", "/dev/null"]
 RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /bin/bash --version)", "/dev/null"]
 
-ENTRYPOINT ["/usr/bin/zsh"]
-CMD ["-c", "lind /fork; lind /hello; lind /bin/bash --version; exec zsh"]
+CMD ["/usr/bin/bash", "-c", "lind /fork; lind /hello; lind /bin/bash --version; exec bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+FROM alyptik/lind:prebuiltsdk
+LABEL lind "v1.0-rc4"
+LABEL description "Lind NaCl Runtime (Pre-built)"
+MAINTAINER Joey Pabalinas <joeypabalinas@gmail.com>
+
+ENV LIND_PREFIX "/home/lind"
+ENV LIND_BASE "$LIND_PREFIX/lind_project"
+ENV LIND_SRC "$LIND_BASE/lind"
+ENV LIND_MONITOR "$LIND_BASE/reference_monitor"
+ENV REPY_PATH "$LIND_SRC/repy"
+ENV NACL_SDK_ROOT "$REPY_PATH/sdk"
+ENV PYTHON "python2"
+ENV PNACLPYTHON "python2"
+ENV LD_LIBRARY_PATH "/lib/glibc"
+ENV PATH "$NACL_SDK_ROOT/toolchain/linux_x86_glibc/bin:$PATH"
+ENV PATH "$REPY_PATH/bin:$PATH"
+ENV PATH "$LIND_BASE:$PATH"
+ENV PATH "/root/bin:/home/lind/bin:$PATH"
+ENV PATH "/root/.local/bin:/home/lind/.local/bin:$PATH"
+
+USER lind
+
+WORKDIR /home/lind/lind_project/
+RUN ["./mklind", "-qe", "nacl"]
+RUN ["./mklind", "-qe", "repy"]
+RUN ["./mklind", "-qe", "install"]
+RUN ["/usr/bin/env", "x86_64-nacl-gcc", "test_cases/fork.c", "-o", "lind/repy/repy/fork"]
+RUN ["/usr/bin/env", "x86_64-nacl-gcc", "test_cases/hello.c", "-o", "lind/repy/repy/hello"]
+WORKDIR /home/lind/lind_project/test_cases/bash/
+RUN ["./bootstrap_nacl", "--prefix=/home/lind/lind_project/lind/repy/repy"]
+RUN ["/usr/bin/make", "install"]
+
+WORKDIR /home/lind/lind_project/lind/repy/repy/
+RUN ["/usr/bin/env", "lindfs", "cp", "./bin/"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./lib/"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./share/"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./fork"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./hello"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./.bashrc"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./.bash_logout"]
+RUN ["/usr/bin/env", "lindfs", "cp", "./.bash_profile"]
+RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /fork)", "/dev/null"]
+RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /hello)", "/dev/null"]
+RUN ["/usr/bin/env", "script", "-qfc", "$(printf '%q ' lind /bin/bash --version)", "/dev/null"]
+
+ENTRYPOINT ["/usr/bin/zsh"]
+CMD ["-c", "lind /fork; lind /hello; lind /bin/bash --version; exec zsh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,24 +15,15 @@ USER lind
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN git submodule update --recursive --remote .
-RUN ./mklind -q nacl
-RUN ./mklind -q repy
-RUN ./mklind -q install
-RUN x86_64-nacl-gcc test_cases/fork.c -o lind/repy/repy/fork
-RUN x86_64-nacl-gcc test_cases/hello.c -o lind/repy/repy/hello
+RUn for t in nacl repy install; do ./mklind -q "$t"; done
+RUN env x86_64-nacl-gcc test_cases/fork.c -o lind/repy/repy/fork
+RUN env x86_64-nacl-gcc test_cases/hello.c -o lind/repy/repy/hello
 WORKDIR /home/lind/lind_project/test_cases/bash/
 RUN ./bootstrap_nacl --prefix="/home/lind/lind_project/lind/repy/repy"
 RUN make install
 
 WORKDIR /home/lind/lind_project/lind/repy/repy/
-RUN lindfs cp ./bin/
-RUN lindfs cp ./lib/
-RUN lindfs cp ./share/
-RUN lindfs cp ./fork
-RUN lindfs cp ./hello
-RUN lindfs cp ./.bashrc
-RUN lindfs cp ./.bash_logout
-RUN lindfs cp ./.bash_profile
+RUN for f in ./bin/ ./lib/ ./share/ ./fork ./hello ./.bashrc ./.bash_logout ./.bash_profile; do lindfs cp "$f"; done
 RUN script -qfc "$(printf '%q ' lind /fork)" /dev/null
 RUN script -qfc "$(printf '%q ' lind /hello)" /dev/null
 RUN script -qfc "$(printf '%q ' lind /bin/bash --version)" /dev/null

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ USER lind
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
 RUN git submodule update --recursive --remote .
-RUn for t in nacl repy install; do ./mklind -q "$t"; done
-RUn for t in nacl repy install; do ./mklind -q "$t"; done
+RUN for t in nacl repy install; do ./mklind -q "$t"; done
 RUN x86_64-nacl-gcc "test_cases/fork.c" -o "lind/repy/repy/fork"
 RUN x86_64-nacl-gcc "test_cases/hello.c" -o "lind/repy/repy/hello"
 WORKDIR /home/lind/lind_project/test_cases/bash/

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,6 @@ USER lind
 
 WORKDIR /home/lind/lind_project/
 RUN git pull -t -j8
-RUN git submodule update --recursive --remote .
 RUN for t in nacl repy install; do ./mklind -q "$t"; done
 RUN x86_64-nacl-gcc "test_cases/fork.c" -o "lind/repy/repy/fork"
 RUN x86_64-nacl-gcc "test_cases/hello.c" -o "lind/repy/repy/hello"

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ LABEL lind "v1.0-rc4"
 LABEL description "Lind NaCl Runtime (Pre-built)"
 MAINTAINER Joey Pabalinas <joeypabalinas@gmail.com>
 
-# defaults to develop
 ARG BRANCH
+ENV BRANCH "${BRANCH:-develop}"
 
 ENV LIND_PREFIX "/home/lind"
 ENV LIND_BASE "$LIND_PREFIX/lind_project"


### PR DESCRIPTION
I decided to just split out the glibc parts of the build which simplified everything significantly. As an added bonus, with this particular solution we wouldn't need to worry about hosting or maintaining webhooks anymore.

@lukpueh, since you have the most experience with this stuff, does this approach seem alright to you? It isn't the most elegant solution, but this seems to be the most reliable way to test NaCl changes without having to rebuild the entire toolchain every time we push a commit: [native_client/builds/450379081](https://travis-ci.org/Lind-Project/native_client/builds/450379081).

After some thought, I realized we barely ever change glibc itself, so it's pretty wasteful to rebuild it every time we push a commit to NaCl. Since nothing in NaCl would be able to affect the success of our glibc build, it's been completely divorced from this repository.

The script commands are used to ignore the non-zero exit codes, while still making sure the commands themselves start up correctly and actually load our binaries. They will, however, always fail after ELF loading, since there is currently no way to tell `docker build` to mount `/dev/shm` executable (`docker run` provides the `--ipc=host` flag for this) in just the `Dockerfile`. NaCl requires executable `/dev/shm` because it maps our ELF there and executes that memory at runtime.

We could possibly work around this using `docker compose` later on, but that is a bit more complicated and should probably be handled in another PR.

The CI for glibc is still a bit problematic, as it times out even when building nothing **except** glibc: [Dockerfile#L24](https://github.com/Lind-Project/lind_project/blob/develop/docker/prebuiltsdk/Dockerfile#L24). Since it's not something we change very often, I don't believe it should be a high priority right now, and is best handled later with a PR to the glibc subrepository itself.

For reference, the main repository Travis CI builds can be found [here](https://travis-ci.org/Lind-Project/lind_project/builds).

Signed-off-by: Joey Pabalinas <joeypabalinas@gmail.com>