### PR TITLE
Pipe update

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -765,9 +765,9 @@ int lind_flock (int fd, int operation)
     LIND_API_PART3;
 }
 
-int lind_pipe(int* pipefds){
+int lind_pipe(int* pipefds, int cageid){
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[])", LIND_safe_sys_pipe);
+    callArgs = Py_BuildValue("(i[i])", LIND_safe_sys_pipe);
     LIND_API_PART2;
     COPY_DATA(pipefds, 2*sizeof(int))
     LIND_API_PART3;

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -410,6 +410,9 @@ int lind_close (int fd, int cageid)
 
 int lind_read (int fd, int size, void *buf, int cageid)
 { 
+    printf("in lind read reading from cageid: %d fd: %d\n", cageid, fd);
+
+
     LIND_API_PART1;
     callArgs = Py_BuildValue("(i[iii])", LIND_safe_fs_read, fd, size, cageid);
     LIND_API_PART2;
@@ -418,7 +421,12 @@ int lind_read (int fd, int size, void *buf, int cageid)
 }
 
 int lind_write (int fd, size_t count, const void *buf, int cageid)
-{ 
+{
+
+    printf("in lind write writing to cageid: %d fd: %d\n", cageid, fd);
+    printf("%s\n", buf);
+
+
     LIND_API_PART1;
     CHECK_NOT_NULL(buf);
     callArgs = Py_BuildValue("(i[iis#i])", LIND_safe_fs_write, fd, count, buf, count, cageid);

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -767,7 +767,7 @@ int lind_flock (int fd, int operation)
 
 int lind_pipe(int* pipefds, int cageid){
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[i])", LIND_safe_fs_pipe);
+    callArgs = Py_BuildValue("(i[i])", LIND_safe_fs_pipe, cageid);
     LIND_API_PART2;
     COPY_DATA(pipefds, 2*sizeof(int))
     LIND_API_PART3;
@@ -775,7 +775,7 @@ int lind_pipe(int* pipefds, int cageid){
 
 int lind_pipe2(int* pipefds, int flags){
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[i])", LIND_safe_sys_pipe2, flags);
+    callArgs = Py_BuildValue("(i[i])", LIND_safe_fs_pipe2, flags);
     LIND_API_PART2;
     COPY_DATA(pipefds, 2*sizeof(int))
     LIND_API_PART3;

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -410,9 +410,6 @@ int lind_close (int fd, int cageid)
 
 int lind_read (int fd, int size, void *buf, int cageid)
 { 
-    printf("in lind read reading from cageid: %d fd: %d\n", cageid, fd);
-
-
     LIND_API_PART1;
     callArgs = Py_BuildValue("(i[iii])", LIND_safe_fs_read, fd, size, cageid);
     LIND_API_PART2;
@@ -421,12 +418,7 @@ int lind_read (int fd, int size, void *buf, int cageid)
 }
 
 int lind_write (int fd, size_t count, const void *buf, int cageid)
-{
-
-    printf("in lind write writing to cageid: %d fd: %d\n", cageid, fd);
-    printf("%s\n", buf);
-
-
+{ 
     LIND_API_PART1;
     CHECK_NOT_NULL(buf);
     callArgs = Py_BuildValue("(i[iis#i])", LIND_safe_fs_write, fd, count, buf, count, cageid);

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -767,7 +767,7 @@ int lind_flock (int fd, int operation)
 
 int lind_pipe(int* pipefds, int cageid){
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[i])", LIND_safe_sys_pipe);
+    callArgs = Py_BuildValue("(i[i])", LIND_safe_fs_pipe);
     LIND_API_PART2;
     COPY_DATA(pipefds, 2*sizeof(int))
     LIND_API_PART3;

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -789,9 +789,9 @@ int lind_pipe2(int* pipefds, int flags){
     LIND_API_PART3;
 }
 
-int lind_fork(int newcageid){
+int lind_fork(int newcageid, int cageid){
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[i])", LIND_safe_fs_fork, newcageid);
+    callArgs = Py_BuildValue("(i[ii])", LIND_safe_fs_fork, newcageid, cageid);
     LIND_API_PART2;
     LIND_API_PART3;
 }

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -83,7 +83,7 @@
 #define LIND_safe_fs_rename             55
 
 #define LIND_safe_fs_pipe              66
-#define LIND_safe_sys_pipe2             67
+#define LIND_safe_fs_pipe2             67
 #define LIND_safe_fs_fork               68
 
 #define LIND_comp_cia                   105

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -155,6 +155,6 @@ int lind_getegid (gid_t * buf);
 int lind_flock (int fd, int operation);
 int lind_pipe(int* pipefds, int cageid);
 int lind_pipe2(int* pipefds, int flags);
-int lind_fork(int newcageid);
+int lind_fork(int newcageid, int cageid);
 
 #endif /* LIND_PLATFORM_H_ */

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -82,7 +82,7 @@
 #define LIND_safe_fs_flock              54
 #define LIND_safe_fs_rename             55
 
-#define LIND_safe_sys_pipe              66
+#define LIND_safe_fs_pipe              66
 #define LIND_safe_sys_pipe2             67
 #define LIND_safe_fs_fork               68
 

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -153,7 +153,7 @@ int lind_geteuid (uid_t * buf);
 int lind_getgid (gid_t * buf);
 int lind_getegid (gid_t * buf);
 int lind_flock (int fd, int operation);
-int lind_pipe(int* pipefds);
+int lind_pipe(int* pipefds, int cageid);
 int lind_pipe2(int* pipefds, int flags);
 int lind_fork(int newcageid);
 

--- a/src/shared/platform/nacl_host_desc.h
+++ b/src/shared/platform/nacl_host_desc.h
@@ -163,6 +163,13 @@ extern int NaClHostDescUnmapUnsafe(void   *start_addr,
  */
 #define NACL_ALLOWED_OPEN_FLAGS \
   (NACL_ABI_O_ACCMODE | NACL_ABI_O_CREAT | NACL_ABI_O_TRUNC | NACL_ABI_O_APPEND)
+/*
+ * Wrapper for creating Pipe descriptor
+ * Calls Ctor
+ */
+extern int NaClHostDescPipe(struct NaClHostDesc  *d,
+                            int fd,
+                            int flags) NACL_WUR;
 
 /*
  * Constructor for a NaClHostDesc object.

--- a/src/shared/platform/posix/nacl_host_desc.c
+++ b/src/shared/platform/posix/nacl_host_desc.c
@@ -245,6 +245,12 @@ static int NaClHostDescCtor(struct NaClHostDesc  *d,
   return 0;
 }
 
+int NaClHostDescPipe(struct NaClHostDesc  *d,
+                            int fd,
+                            int flags) {
+  return NaClHostDescCtor(d, fd, flags);
+}
+
 int NaClHostDescOpen(struct NaClHostDesc  *d,
                      char const           *path,
                      int                  flags,

--- a/src/trusted/desc/nacl_desc_base.h
+++ b/src/trusted/desc/nacl_desc_base.h
@@ -441,7 +441,6 @@ struct NaClDesc {
   int32_t metadata_type;
   uint32_t metadata_num_bytes;
   uint8_t *metadata;
-  int open_refs;
 };
 
 /*

--- a/src/trusted/desc/nacl_desc_base.h
+++ b/src/trusted/desc/nacl_desc_base.h
@@ -441,6 +441,7 @@ struct NaClDesc {
   int32_t metadata_type;
   uint32_t metadata_num_bytes;
   uint8_t *metadata;
+  int open_refs;
 };
 
 /*

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -143,33 +143,59 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     NaClLog(LOG_FATAL, "Launch service threads failed\n");
   }
 
-  printf("\nDuplicating FD TABLE\n");
+  // print_desctbl(nap_parent);
+  // print_desctbl(nap_child);
+  // printf("\nDuplicating FD TABLE\n");
   /* duplicate file descriptor table starting at child_fd = 3 (0-2 setup previously)*/
   NaClXMutexLock(&nap_parent->mu);
   for (int parent_fd = nap_child->fd; parent_fd <= nap_parent->fd; parent_fd++) {
 
     /* Retrive the host fd we had stored in the Cage Table for the parent */
     int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];
-
+    if (parent_host_fd == 0) {
+      fd_cage_table[nap_child->cage_id][nap_child->fd++] = 0;
+      continue;
+    }
     /* Retrieve Parent NaCl Descriptor based on current child fd in the parent */
     struct NaClDesc *parent_nd;
     parent_nd = NaClGetDesc(nap_parent, parent_host_fd);
     if (!parent_nd) {
       continue;
     }
-    parent_nd->open_refs++;
 
-    /* Set a new NaClDescriptor in the child duplicating the parent's nd with the parent fd we had stored in cage table  */
-    NaClSetDesc(nap_child, parent_host_fd, parent_nd);
+    /* Translate from NaCl Desc to Host Desc */
+    struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) &parent_nd->base;
+    struct NaClHostDesc *parent_hd = self->hd;
+
+    /* Create and set vars for child hd */
+    struct NaClHostDesc *child_hd;
+    child_hd = malloc(sizeof(*child_hd));
+    if (!child_hd) {
+        NaClLog(LOG_FATAL, "NaClChildNapCtor: Error initializing child descriptor\n");
+    }
+
+    child_hd->d = parent_hd->d;
+    child_hd->flags = parent_hd->flags;
+    child_hd->cageid = nap_child->cage_id;
+
+    /* Create and set new NaClDesc from Child HD in Child nap */
+    int child_host_fd = NaClSetAvail(nap_child, ((struct NaClDesc *) NaClDescIoDescMake(child_hd)));
+
+    /* We've got to put that parent NaClDescriptor back in there... */
+    NaClSetDesc(nap_parent, parent_host_fd, parent_nd);
 
     /* Set childs cage table with the current fd to the old parent host fd */
-    fd_cage_table[nap_child->cage_id][nap_child->fd++] = parent_host_fd;
+    fd_cage_table[nap_child->cage_id][nap_child->fd++] = child_host_fd;
 
-    printf("We copied Parent cage FD: %d with parent host fd: %d to child cage fd: %d\n", parent_fd, parent_host_fd, nap_child->fd - 1);
+    // printf("We copied Parent cage fd: %d with parent host fd: %d and lind fd: %d\n", parent_fd, parent_host_fd, parent_hd->d);
+    // printf("to child cage fd: %d with child host fd: %d and lind fd: %d\n", nap_child->fd - 1, child_host_fd, child_hd->d);
 
     NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", parent_fd, nap_child->fd - 1);
   }
   NaClXMutexUnlock(&nap_parent->mu);
+  // print_desctbl(nap_parent);
+  // print_desctbl(nap_child);
+
 
   return nap_child;
 }

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -187,8 +187,8 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     /* Set childs cage table with the current fd to the old parent host fd */
     fd_cage_table[nap_child->cage_id][nap_child->fd++] = child_host_fd;
 
-    // printf("We copied Parent cage fd: %d with parent host fd: %d and lind fd: %d\n", parent_fd, parent_host_fd, parent_hd->d);
-    // printf("to child cage fd: %d with child host fd: %d and lind fd: %d\n", nap_child->fd - 1, child_host_fd, child_hd->d);
+    printf("We copied Parent cage fd: %d with parent host fd: %d and lind fd: %d\n", parent_fd, parent_host_fd, parent_hd->d);
+    printf("to child cage fd: %d with child host fd: %d and lind fd: %d\n", nap_child->fd - 1, child_host_fd, child_hd->d);
 
     NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", parent_fd, nap_child->fd - 1);
   }

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -143,17 +143,29 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     NaClLog(LOG_FATAL, "Launch service threads failed\n");
   }
 
-  /* duplicate file descriptor table */
+  printf("\nDuplicating FD TABLE\n");
+  /* duplicate file descriptor table starting at child_fd = 3 (0-2 setup previously)*/
   NaClXMutexLock(&nap_parent->mu);
-  for (int old_fd = nap_child->fd, new_fd = old_fd; old_fd < nap_parent->fd; new_fd = ++old_fd) {
-    struct NaClDesc *old_nd;
-    old_nd = NaClGetDesc(nap_parent, old_fd);
-    if (!old_nd) {
+  for (int parent_fd = nap_child->fd; parent_fd <= nap_parent->fd; parent_fd++) {
+
+    /* Retrieve Parent NaCl Descriptor based on current child fd in the parent */
+    struct NaClDesc *parent_nd;
+    parent_nd = NaClGetDesc(nap_parent, parent_fd);
+    if (!parent_nd) {
       continue;
     }
-    NaClSetDesc(nap_child, new_fd, old_nd);
-    fd_cage_table[nap_child->cage_id][nap_child->fd++] = new_fd;
-    NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", old_fd, nap_child->fd - 1);
+    /* Retrive the host fd we had stored in the Cage Table for the parent */
+    int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];
+
+    /* Set a new NaClDescriptor in the child duplicating the parent's nd with the parent fd we had stored in cage table  */
+    NaClSetDesc(nap_child, parent_host_fd, parent_nd);
+
+    /* Set childs cage table with the current fd to the old parent host fd */
+    fd_cage_table[nap_child->cage_id][nap_child->fd++] = parent_host_fd;
+
+    printf("We copied Parent cage FD: %d with parent host fd: %d to child cage fd: %d\n", parent_fd, parent_host_fd, nap_child->fd - 1);
+
+    NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", parent_fd, nap_child->fd - 1);
   }
   NaClXMutexUnlock(&nap_parent->mu);
 

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -143,9 +143,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     NaClLog(LOG_FATAL, "Launch service threads failed\n");
   }
 
-  // print_desctbl(nap_parent);
-  // print_desctbl(nap_child);
-  // printf("\nDuplicating FD TABLE\n");
+  
   /* duplicate file descriptor table starting at child_fd = 3 (0-2 setup previously)*/
   NaClXMutexLock(&nap_parent->mu);
   for (int parent_fd = nap_child->fd; parent_fd <= nap_parent->fd; parent_fd++) {
@@ -187,14 +185,10 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     /* Set childs cage table with the current fd to the old parent host fd */
     fd_cage_table[nap_child->cage_id][nap_child->fd++] = child_host_fd;
 
-    // printf("We copied Parent cage fd: %d with parent host fd: %d and lind fd: %d\n", parent_fd, parent_host_fd, parent_hd->d);
-    // printf("to child cage fd: %d with child host fd: %d and lind fd: %d\n", nap_child->fd - 1, child_host_fd, child_hd->d);
 
     NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", parent_fd, nap_child->fd - 1);
   }
   NaClXMutexUnlock(&nap_parent->mu);
-  // print_desctbl(nap_parent);
-  // print_desctbl(nap_child);
 
 
   return nap_child;

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -148,14 +148,16 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
   NaClXMutexLock(&nap_parent->mu);
   for (int parent_fd = nap_child->fd; parent_fd <= nap_parent->fd; parent_fd++) {
 
+    /* Retrive the host fd we had stored in the Cage Table for the parent */
+    int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];
+
     /* Retrieve Parent NaCl Descriptor based on current child fd in the parent */
     struct NaClDesc *parent_nd;
-    parent_nd = NaClGetDesc(nap_parent, parent_fd);
+    parent_nd = NaClGetDesc(nap_parent, parent_host_fd);
     if (!parent_nd) {
       continue;
     }
-    /* Retrive the host fd we had stored in the Cage Table for the parent */
-    int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];
+    parent_nd->open_refs++;
 
     /* Set a new NaClDescriptor in the child duplicating the parent's nd with the parent fd we had stored in cage table  */
     NaClSetDesc(nap_child, parent_host_fd, parent_nd);

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -187,8 +187,8 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     /* Set childs cage table with the current fd to the old parent host fd */
     fd_cage_table[nap_child->cage_id][nap_child->fd++] = child_host_fd;
 
-    printf("We copied Parent cage fd: %d with parent host fd: %d and lind fd: %d\n", parent_fd, parent_host_fd, parent_hd->d);
-    printf("to child cage fd: %d with child host fd: %d and lind fd: %d\n", nap_child->fd - 1, child_host_fd, child_hd->d);
+    // printf("We copied Parent cage fd: %d with parent host fd: %d and lind fd: %d\n", parent_fd, parent_host_fd, parent_hd->d);
+    // printf("to child cage fd: %d with child host fd: %d and lind fd: %d\n", nap_child->fd - 1, child_host_fd, child_hd->d);
 
     NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", parent_fd, nap_child->fd - 1);
   }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -3875,7 +3875,7 @@ int32_t NaClSysPipe(struct NaClAppThread  *natp, uint32_t *pipedes) {
   /**
    * Attempt lind pipe RPC. Return lind pipe fds, if not return NaCl Error */
   
-  ret = lind_pipe(lind_fds);
+  ret = lind_pipe(lind_fds, nap->cageid);
   if (-1 = ret) {
     NaClLog(2, "NaClSysPipe: pipe returned -1, errno %d\n", errno);
     return -NaClXlateErrno(errno);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -3992,7 +3992,7 @@ int32_t NaClSysFork(struct NaClAppThread *natp) {
   }
 
   /* success */
-  lind_fork(ret);
+  lind_fork(ret, nap->cage_id);
   NaClLog(1, "[fork_num = %u, child = %u, parent = %u]\n", fork_num, nap_child->cage_id, nap->cage_id);
 
 fail:

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -686,8 +686,8 @@ int32_t NaClSysOpen(struct NaClAppThread  *natp,
     hd->cageid = nap->cage_id;
 
     retval = NaClHostDescOpen(hd, path, flags, mode);
-    NaClLog(1, "NaClHostDescOpen(0x%08"NACL_PRIxPTR", %s, 0%o, 0%o) returned %d\n",
-            (uintptr_t) hd, path, flags, mode, retval);
+    NaClLog(1, "Cage %d NaClHostDescOpen(0x%08"NACL_PRIxPTR", %s, 0%o, 0%o) returned %d\n",
+            nap->cage_id, (uintptr_t) hd, path, flags, mode, retval);
     if (!retval) {
       retval = NaClSetAvail(nap, ((struct NaClDesc *) NaClDescIoDescMake(hd)));
       NaClLog(1, "Entered into open file table at %d\n", retval);
@@ -722,8 +722,8 @@ int32_t NaClSysClose(struct NaClAppThread *natp, int d) {
 
   // printf("Printing desc table at start of close for posterity...\n");
   // print_desctbl(nap);
-  NaClLog(1, "Entered NaClSysClose(0x%08"NACL_PRIxPTR", %d)\n",
-          (uintptr_t) natp, d);
+  NaClLog(1, "Cage %d Entered NaClSysClose(0x%08"NACL_PRIxPTR", %d)\n",
+          nap->cage_id, (uintptr_t) natp, d);
 
   // printf("Closing NaCl fd: %d in cage %d\n", d, nap->cage_id);
 
@@ -744,9 +744,9 @@ int32_t NaClSysClose(struct NaClAppThread *natp, int d) {
 
   /* We're going to check how many references are left before closing it through NaCl */
   if (fd && ndp){
-    NaClLog(1, "Invoking Close virtual function of object 0x%08"NACL_PRIxPTR"\n", (uintptr_t) ndp);
-    // printf("Printing desc table at before set desc mu for posterity...\n");
-    // print_desctbl(nap);
+    // NaClLog(1, "Invoking Close virtual function of object 0x%08"NACL_PRIxPTR"\n", (uintptr_t) ndp);
+    // // printf("Printing desc table at before set desc mu for posterity...\n");
+    // // print_desctbl(nap);
     NaClSetDescMu(nap, fd, NULL);
     // printf("Printing desc table after setdesc, before descunref for posterity...\n");
     // print_desctbl(nap);
@@ -855,10 +855,10 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   size_t          log_bytes;
   char const      *ellipsis = "";
 
-  NaClLog(2, "Entered NaClSysRead(0x%08"NACL_PRIxPTR", "
+  NaClLog(2, "Cage %d Entered NaClSysRead(0x%08"NACL_PRIxPTR", "
            "%d, 0x%08"NACL_PRIxPTR", "
            "%"NACL_PRIdS"[0x%"NACL_PRIxS"])\n",
-          (uintptr_t) natp, d, (uintptr_t) buf, count, count);
+          nap->cage_id, (uintptr_t) natp, d, (uintptr_t) buf, count, count);
 
 
   //printf("Reading from NaCl fd: %d in cage %d\n", d, nap->cage_id);
@@ -942,10 +942,10 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   // printf("Writing to NaCl fd: %d in cage %d\n", d, nap->cage_id);
 
-  NaClLog(2, "Entered NaClSysWrite(0x%08"NACL_PRIxPTR", "
+  NaClLog(2, "Cage %d Entered NaClSysWrite(0x%08"NACL_PRIxPTR", "
           "%d, 0x%08"NACL_PRIxPTR", "
           "%"NACL_PRIdS"[0x%"NACL_PRIxS"])\n",
-          (uintptr_t) natp, d, (uintptr_t) buf, count, count);
+          nap->cage_id, (uintptr_t) natp, d, (uintptr_t) buf, count, count);
 
   ndp = NaClGetDesc(nap, fd);
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -619,8 +619,7 @@ int32_t NaClSetAvailMu(struct NaClApp  *nap,
   }
 
   NaClSetDescMu(nap, (int) pos, ndp);
-  ndp->open_refs = 1;
-
+  
   return (int32_t) pos;
 }
 
@@ -1750,3 +1749,14 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
   nap->cage_id = cage_id;
 }
 
+void print_desctbl(struct NaClApp *nap)
+{
+  printf("--------------------------");
+  printf("printing desc table for nap w cageid: %d\n", nap->cage_id);
+  printf("ptr array at length %d\n", nap->desc_tbl.num_entries);
+  for (int i = 0; i < nap->desc_tbl.num_entries; i++)
+  {
+    printf("Pointer for %d 0x%" PRIXPTR "\n", i, (uintptr_t)nap->desc_tbl.ptr_array[i]);
+  }
+  printf("---------------------------");
+}

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1749,14 +1749,3 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
   nap->cage_id = cage_id;
 }
 
-void print_desctbl(struct NaClApp *nap)
-{
-  printf("--------------------------");
-  printf("printing desc table for nap w cageid: %d\n", nap->cage_id);
-  printf("ptr array at length %d\n", nap->desc_tbl.num_entries);
-  for (int i = 0; i < nap->desc_tbl.num_entries; i++)
-  {
-    printf("Pointer for %d 0x%" PRIXPTR "\n", i, (uintptr_t)nap->desc_tbl.ptr_array[i]);
-  }
-  printf("---------------------------");
-}

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -72,7 +72,6 @@ double time_end = 0.0;
  * -jp
  */
 volatile sig_atomic_t fork_num;
-struct Pipe pipe_table[PIPE_NUM_MAX];
 int fd_cage_table[CAGING_FD_NUM][CAGING_FD_NUM];
 int cached_lib_num;
 

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -619,6 +619,7 @@ int32_t NaClSetAvailMu(struct NaClApp  *nap,
   }
 
   NaClSetDescMu(nap, (int) pos, ndp);
+  ndp->open_refs = 1;
 
   return (int32_t) pos;
 }

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -1015,8 +1015,6 @@ static INLINE void NaClLogAddressSpaceLayout(struct NaClApp *nap) {
   NaClLog(2, "nap->bundle_size        = 0x%x\n", nap->bundle_size);
 }
 
-void print_desctbl(struct NaClApp *nap);
-
 EXTERN_C_END
 
 #endif  /* NATIVE_CLIENT_SRC_TRUSTED_SERVICE_RUNTIME_SEL_LDR_H_ */

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -80,14 +80,7 @@ struct NaClThreadInterface;  /* see sel_ldr_thread_interface.h */
 struct NaClValidationCache;
 struct NaClValidationMetadata;
 
-struct Pipe {
-  bool xfer_done;
-  bool is_closed;
-  struct NaClFastMutex mu;
-};
-
 extern volatile sig_atomic_t fork_num;
-extern struct Pipe pipe_table[PIPE_NUM_MAX];
 extern int fd_cage_table[CAGING_FD_NUM][CAGING_FD_NUM];
 extern int cached_lib_num;
 

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -1015,6 +1015,8 @@ static INLINE void NaClLogAddressSpaceLayout(struct NaClApp *nap) {
   NaClLog(2, "nap->bundle_size        = 0x%x\n", nap->bundle_size);
 }
 
+void print_desctbl(struct NaClApp *nap);
+
 EXTERN_C_END
 
 #endif  /* NATIVE_CLIENT_SRC_TRUSTED_SERVICE_RUNTIME_SEL_LDR_H_ */

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -838,17 +838,6 @@ int NaClSelLdrMain(int argc, char **argv) {
   nap->argv = argv + optind;
   nap->binary = argv[optind + 3];
 
-  NaClLog(1, "%s\n", "Initializing pipe table mutexes/conditional variables.");
-
-  for (size_t i = 0; i < PIPE_NUM_MAX; i++) {
-    if (!NaClFastMutexCtor(&pipe_table[i].mu)) {
-      NaClLog(LOG_ERROR, "%s\n", "pipe mutex ctor failed");
-      goto done;
-    }
-    pipe_table[i].xfer_done = true;
-    pipe_table[i].is_closed = false;
-  }
-
   NaClLog(1, "%s\n\n", "[NaCl Main Loader] before creation of the cage to run user program!");
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
   nacl_initialization_finish = clock();


### PR DESCRIPTION
NaCl updates to implement `pipe` in SafePOSIX.

This accomplishes ripping out the old pipetable that was in NaCl and transferring pipes to SafePOSIX. This also updates how NaCl descs are replicated on fork.

For review:
in nacl_app_thread.c:
- updates NaCl desc replication on fork

in nacl_syscall_common.c:
- NaClSysPipe now gets fds from lind, sets them up as NaCl descriptors, and manages cagetable.