### PR TITLE
Exec fix

### DIFF
--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4059,9 +4059,10 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   struct NaClApp *nap = natp->nap;
   struct NaClApp *nap_child = 0;
   struct NaClEnvCleanser env_cleanser = {0};
-  char *sys_pathname = NaClUserToSysAddr(nap, path);
-  char **sys_envp = NaClUserToSysAddr(nap, envp);
-  char **sys_argv = NaClUserToSysAddr(nap, argv);
+  char *sys_pathname = NaClUserToSysAddr(nap, (uintptr_t)path);
+
+  uint32_t* sys_envp = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)envp);
+  uint32_t* sys_argv = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)argv);
 
   char* arg1 = NaClUserToSysAddr(nap, sys_argv[0]);
   char *binary = sys_pathname ? strdup(sys_pathname) : 0;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4055,17 +4055,14 @@ fail:
   return ret;
 }
 
-int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, int argc, char *const *envp, int envc) {
+int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, char *const *envp) {
   struct NaClApp *nap = natp->nap;
   struct NaClApp *nap_child = 0;
   struct NaClEnvCleanser env_cleanser = {0};
-  char *sys_pathname = NaClUserToSysAddr(nap, (uintptr_t)path);
-
-  uint32_t* sys_envp = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)envp);
-  uint32_t* sys_argv = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)argv);
-
-  char* arg1 = NaClUserToSysAddr(nap, sys_argv[0]);
-  char *binary = sys_pathname ? strdup(sys_pathname) : 0;
+  char *sys_pathname;
+  uint32_t *sys_argv_ptr;
+  uint32_t *sys_envp_ptr = { NULL };
+  char *binary; 
   char **child_argv = 0;
   char **new_argv = 0;
   char **new_envp = 0;
@@ -4083,13 +4080,24 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   uintptr_t child_start_addr;
   uintptr_t tramp_pnum;
 
+  /* Convert pathname from user path, set binary */
+  sys_pathname = NaClUserToSysAddr(nap, (uintptr_t)path);
+  binary = sys_pathname ? strdup(sys_pathname) : 0;
+
+  /* Convert to a Sys Pointer for argv** */
+  sys_argv_ptr = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)argv);
+
+  /* Make sys_envp_ptr a NULL array if we were passed NULL by EXECV */
+  if (envp) sys_envp_ptr = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)envp);
+
+
   NaClLog(1, "%s\n", "[NaClSysExecve] NaCl execve() starts!");
 
-  /* set up environment */
+  /* set up environment, only do this if we initially were passed an environment*/
   NaClEnvCleanserCtor(&env_cleanser, 0);
-  if (sys_envp) {
+  if (envp) {
     /* count number of environment strings */
-    for (char **pp = sys_envp; *pp; ++pp) {
+    for (char **pp = sys_envp_ptr; *pp; ++pp) {
       new_envc++;
     }
     new_envp = calloc(new_envc + 1, sizeof(*new_envp));
@@ -4099,7 +4107,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
       goto fail;
     }
     for (int i = 0; i < new_envc; i++) {
-      char *env = (void *)NaClUserToSysAddr(nap, (uintptr_t)sys_envp[i]);
+      char *env = (void *)NaClUserToSysAddr(nap, (uintptr_t)sys_envp_ptr[i]);
       env = (uintptr_t)env == kNaClBadAddress ? 0 : env;
       new_envp[i] = env ? strdup(env) : 0;
       if (!env) {
@@ -4116,12 +4124,12 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   }
 
   /* set up argv and argc */
-  if (!sys_argv) {
+  if (!sys_argv_ptr) {
     NaClLog(LOG_ERROR, "%s\n", "Passed a NULL pointer in argp");
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;
   }
-  for (char **pp = sys_argv; *pp; ++pp) {
+  for (char **pp = sys_argv_ptr; *pp; ++pp) {
     new_argc++;
   }
   new_argv = calloc(new_argc + 1, sizeof(*new_argv));
@@ -4131,7 +4139,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
     goto fail;
   }
   for (int i = 0; i < new_argc; i++) {
-    char *arg = (void *)NaClUserToSysAddr(nap, (uintptr_t)sys_argv[i]);
+    char *arg = (void *)NaClUserToSysAddr(nap, (uintptr_t)sys_argv_ptr[i]);
     arg = (uintptr_t)arg == kNaClBadAddress ? 0 : arg;
     new_argv[i] = arg ? strdup(arg) : 0;
     if (!arg) {
@@ -4310,8 +4318,9 @@ fail:
 }
 
 int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv) {
-  char* envp[] = { NULL };
-  return NaClSysExecve(natp, pathname, argv, 0, envp, 0);
+  struct NaClApp *nap = natp->nap;
+
+  return NaClSysExecve(natp, pathname, argv, NULL);
 }
 
 #define WAIT_ANY (-1)

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4084,7 +4084,11 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   sys_pathname = NaClUserToSysAddr(nap, (uintptr_t)path);
   binary = sys_pathname ? strdup(sys_pathname) : 0;
 
-  /* Convert to a Sys Pointer for argv** */
+  /* 
+    Convert to a Sys Pointer for argv** 
+    We need to turn these to uint32_t pointers for now because these are still NaCl pointers
+    We'll convert to a char** later.
+  */
   sys_argv_ptr = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)argv);
 
   /* Make sys_envp_ptr a NULL array if we were passed NULL by EXECV */
@@ -4176,9 +4180,11 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   nap_child = NaClChildNapCtor(nap);
   nap_child->running = 0;
   nap_child->in_fork = 0;
+
   /* TODO: fix dynamic text validation -jp */
   nap_child->skip_validator = 1;
   nap_child->main_exe_prevalidated = 1;
+  
   /* calculate page addresses and sizes */
   dyncode_child = (void *)NaClUserToSys(nap_child, nap_child->dynamic_text_start);
   dyncode_size = NaClRoundPage(nap_child->dynamic_text_end - nap->dynamic_text_start);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4323,10 +4323,8 @@ fail:
   return ret;
 }
 
-int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv) {
-  struct NaClApp *nap = natp->nap;
-
-  return NaClSysExecve(natp, pathname, argv, NULL);
+int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *argv) {
+  return NaClSysExecve(natp, path, argv, NULL);
 }
 
 #define WAIT_ANY (-1)

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4055,13 +4055,15 @@ fail:
   return ret;
 }
 
-int32_t NaClSysExecve(struct NaClAppThread *natp, void *pathname, void *argv, void *envp) {
+int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, int argc, char *const *envp, int envc) {
   struct NaClApp *nap = natp->nap;
   struct NaClApp *nap_child = 0;
   struct NaClEnvCleanser env_cleanser = {0};
-  char *sys_pathname = (void *)NaClUserToSysAddr(nap, (uintptr_t)pathname);
-  char **sys_envp = (void *)NaClUserToSysAddr(nap, (uintptr_t)envp);
-  char **sys_argv = (void *)NaClUserToSysAddr(nap, (uintptr_t)argv);
+  char *sys_pathname = NaClUserToSysAddr(nap, path);
+  char **sys_envp = NaClUserToSysAddr(nap, envp);
+  char **sys_argv = NaClUserToSysAddr(nap, argv);
+
+  char* arg1 = NaClUserToSysAddr(nap, sys_argv[0]);
   char *binary = sys_pathname ? strdup(sys_pathname) : 0;
   char **child_argv = 0;
   char **new_argv = 0;
@@ -4307,7 +4309,8 @@ fail:
 }
 
 int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv) {
-  return NaClSysExecve(natp, pathname, argv, 0);
+  char* envp[] = { NULL };
+  return NaClSysExecve(natp, pathname, argv, 0, envp, 0);
 }
 
 #define WAIT_ANY (-1)

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -316,7 +316,7 @@ int32_t NaClSysPipe(struct NaClAppThread *natp, uint32_t *pipedes);
 int32_t NaClSysPipe2(struct NaClAppThread *natp, uint32_t *pipedes, int flags);
 int32_t NaClSysFork(struct NaClAppThread *natp);
 int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, char *const *envp);
-int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv);
+int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *argv);
 int32_t NaClSysWaitpid(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options);
 int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc);
 int32_t NaClSysWait4(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options, void *rusage);

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -315,7 +315,7 @@ int32_t NaClSysTestCrash(struct NaClAppThread *natp, int crash_type);
 int32_t NaClSysPipe(struct NaClAppThread *natp, uint32_t *pipedes);
 int32_t NaClSysPipe2(struct NaClAppThread *natp, uint32_t *pipedes, int flags);
 int32_t NaClSysFork(struct NaClAppThread *natp);
-int32_t NaClSysExecve(struct NaClAppThread *natp, void* pathname, void* argv, void* envp);
+int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, int argc, char *const *envp, int envc);
 int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv);
 int32_t NaClSysWaitpid(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options);
 int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc);

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -315,7 +315,7 @@ int32_t NaClSysTestCrash(struct NaClAppThread *natp, int crash_type);
 int32_t NaClSysPipe(struct NaClAppThread *natp, uint32_t *pipedes);
 int32_t NaClSysPipe2(struct NaClAppThread *natp, uint32_t *pipedes, int flags);
 int32_t NaClSysFork(struct NaClAppThread *natp);
-int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, int argc, char *const *envp, int envc);
+int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, char *const *envp);
 int32_t NaClSysExecv(struct NaClAppThread *natp, void *pathname, void *argv);
 int32_t NaClSysWaitpid(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options);
 int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc);

--- a/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
+++ b/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
@@ -246,7 +246,7 @@ SYSCALL_LIST = [
     ('NACL_sys_lind_syscall', 'NaClSysLindSyscall', ['uint32_t callNum', 'uint32_t inNum', 'void *inArgs', 'uint32_t outNum', 'void *outArgs']),
     ('NACL_sys_fork', 'NaClSysFork', []),
     ('NACL_sys_execv', 'NaClSysExecv', ['void *path', 'void *argv']),
-    ('NACL_sys_execve', 'NaClSysExecve', ['void *path', 'void *argv', 'void *envp']),
+    ('NACL_sys_execve', 'NaClSysExecve', ['const char *path', 'void *argv', 'int argc', 'void *envp', 'int envc']),
     ('NACL_sys_pipe', 'NaClSysPipe', ['uint32_t *pipedes']),
     ('NACL_sys_pipe2', 'NaClSysPipe2', ['uint32_t *pipedes', 'int flags']),
     ('NACL_sys_getppid', 'NaClSysGetppid', []),

--- a/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
+++ b/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
@@ -246,7 +246,7 @@ SYSCALL_LIST = [
     ('NACL_sys_lind_syscall', 'NaClSysLindSyscall', ['uint32_t callNum', 'uint32_t inNum', 'void *inArgs', 'uint32_t outNum', 'void *outArgs']),
     ('NACL_sys_fork', 'NaClSysFork', []),
     ('NACL_sys_execv', 'NaClSysExecv', ['void *path', 'void *argv']),
-    ('NACL_sys_execve', 'NaClSysExecve', ['const char *path', 'void *argv', 'int argc', 'void *envp', 'int envc']),
+    ('NACL_sys_execve', 'NaClSysExecve', ['const char *path', 'void *argv', 'void *envp']),
     ('NACL_sys_pipe', 'NaClSysPipe', ['uint32_t *pipedes']),
     ('NACL_sys_pipe2', 'NaClSysPipe2', ['uint32_t *pipedes', 'int flags']),
     ('NACL_sys_getppid', 'NaClSysGetppid', []),


### PR DESCRIPTION
This is mostly in `nacl_syscall_common.c`

This PR fixes two issues with the Exec family. The more major of which was the improper conversion of NaCl 2D arrays for argv and envp into system args.

It also fixes `execv` by letting us execute `NaClSysExecve` with a NULL environment. 