### PR TITLE
Thread PR

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -545,9 +545,7 @@ struct NaClAppThread *NaClAppThreadMake(struct NaClApp *nap,
   return NULL;
 }
 
-
-
-int NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
+void NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
                               struct NaClAppThread     *natp_child,
                               void *stack_ptr_parent,
                               void *stack_ptr_child) {
@@ -665,7 +663,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
   }
   else {
     user_tls1 = (uint32_t)natp_parent->user.tls_value1;
-    user_tls2 = (uint32_t)natp_parent->user.tls_value2);
+    user_tls2 = (uint32_t)natp_parent->user.tls_value2;
   }
 
 
@@ -690,7 +688,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
     * save master thread context pointer
     */
     if (nap_child->cage_id == 1 || !master_ctx) {
-      master_ctx = &natp->user;
+      master_ctx = &natp_child->user;
     }
     nap_child->parent = NULL;
     nap_child->master = ((struct NaClAppThread *)master_ctx)->nap;
@@ -736,7 +734,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
 
 
 
-  if (!NaClThreadCtor(&natp_child->host_thread, NaClAppForkThreadLauncher, natp_child, NACL_KERN_STACK_SIZE)) {
+  if (!NaClThreadCtor(&natp_child->host_thread, NaClAppThreadLauncher, natp_child, NACL_KERN_STACK_SIZE)) {
     /*
     * No other thread saw the NaClAppThread, so it is OK that
     * host_thread was not initialized despite host_thread_is_defined

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -220,7 +220,7 @@ void WINAPI NaClAppThreadLauncher(void *state) {
     NaClSetCurrentMachThreadForThreadIndex(thread_idx);
   #endif
 
-  if (tl_type == FORK){
+  if (tl_type == THREAD_LAUNCH_FORK){
       /*
     * We have to hold the threads_mu and children_mu locks until
     * after thread_num field in this thread has been initialized.
@@ -265,7 +265,7 @@ void WINAPI NaClAppThreadLauncher(void *state) {
     natp->nap->debug_stub_callbacks->thread_create_hook(natp);
   }
 
-  if (tl_type == FORK) {
+  if (tl_type == THREAD_LAUNCH_FORK) {
     #if !NACL_WINDOWS
       /*
       * Ensure stack alignment.  Stack pointer must be -8 mod 16 when no
@@ -309,7 +309,7 @@ void WINAPI NaClAppThreadLauncher(void *state) {
     NaClAppThreadSetSuspendState(natp, NACL_APP_THREAD_TRUSTED, NACL_APP_THREAD_UNTRUSTED);
 
   /* Not exactly sure what hole exec falls into */
-  if (tl_type == FORK) {
+  if (tl_type == THREAD_LAUNCH_FORK) {
     #if NACL_WINDOWS
       /* This sets up a stack containing a return address that has unwind info. */
       NaClSwitchSavingStackPtr(context, &context->trusted_stack_ptr, NaClSwitchToApp);
@@ -635,7 +635,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
 
 
 
-  if (tl_type == FORK) {
+  if (tl_type == THREAD_LAUNCH_FORK) {
     nap_parent = natp_parent->nap;
     if (!nap_parent->running) return 0;
 
@@ -663,7 +663,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
   if (!natp_child) return 0;
 
   /* Create context for master, or use loaded contexts to setup fork */
-  if (tl_type == MAIN){
+  if (tl_type == THREAD_LAUNCH_MAIN){
     /*
     * save master thread context pointer
     */
@@ -673,7 +673,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
     nap_child->parent = NULL;
     nap_child->master = ((struct NaClAppThread *)master_ctx)->nap;
   }
-  else if (tl_type == FORK) {
+  else if (tl_type == THREAD_LAUNCH_FORK) {
     NaClForkThreadContextSetup(natp_parent, natp_child, stack_ptr_parent, stack_ptr_child);
   }
  
@@ -681,7 +681,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
   /*
    * setup TLS slot in the global nacl_user array for Fork/Exec
    */
-  if (tl_type != MAIN) {
+  if (tl_type != THREAD_LAUNCH_MAIN) {
     natp_child->user.tls_idx = nap_child->cage_id;
     if (nacl_user[natp_child->user.tls_idx]) {
       NaClLog(1, "nacl_user[%u] not NULL (%p)\n)",
@@ -700,7 +700,7 @@ int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
    */
   natp_child->host_thread_is_defined = 1;
 
-  if (tl_type == FORK){
+  if (tl_type == THREAD_LAUNCH_FORK){
     NaClXCondVarBroadcast(&nap_parent->cv);
     NaClXMutexUnlock(&nap_parent->mu);
     NaClXMutexUnlock(&nap_child->mu);

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -220,7 +220,7 @@ void WINAPI NaClAppThreadLauncher(void *state) {
     NaClSetCurrentMachThreadForThreadIndex(thread_idx);
   #endif
 
-  if (tl_type != MAIN){
+  if (tl_type == FORK){
       /*
     * We have to hold the threads_mu and children_mu locks until
     * after thread_num field in this thread has been initialized.
@@ -265,7 +265,7 @@ void WINAPI NaClAppThreadLauncher(void *state) {
     natp->nap->debug_stub_callbacks->thread_create_hook(natp);
   }
 
-  if (tl_type != MAIN) {
+  if (tl_type == FORK) {
     #if !NACL_WINDOWS
       /*
       * Ensure stack alignment.  Stack pointer must be -8 mod 16 when no
@@ -309,7 +309,7 @@ void WINAPI NaClAppThreadLauncher(void *state) {
     NaClAppThreadSetSuspendState(natp, NACL_APP_THREAD_TRUSTED, NACL_APP_THREAD_UNTRUSTED);
 
   /* Not exactly sure what hole exec falls into */
-  if (tl_type != MAIN) {
+  if (tl_type == FORK) {
     #if NACL_WINDOWS
       /* This sets up a stack containing a return address that has unwind info. */
       NaClSwitchSavingStackPtr(context, &context->trusted_stack_ptr, NaClSwitchToApp);

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -193,10 +193,12 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
   return nap_child;
 }
 
-void WINAPI NaClAppForkThreadLauncher(void *state) {
+void WINAPI NaClAppThreadLauncher(void *state) {
   struct NaClAppThread *natp = (struct NaClAppThread *) state;
   struct NaClApp *nap = natp->nap;
   struct NaClThreadContext *context = &natp->user;
+  enum NaClThreadLaunchType tl_type = nap->tl_type;
+
   uint32_t thread_idx;
   nacl_reg_t secure_stack_ptr;
 
@@ -212,141 +214,113 @@ void WINAPI NaClAppForkThreadLauncher(void *state) {
   CHECK(thread_idx > 0 && thread_idx < NACL_THREAD_MAX);
   NaClTlsSetCurrentThread(natp);
   nacl_user[thread_idx] = &natp->user;
-#if NACL_WINDOWS
-  nacl_thread_ids[thread_idx] = GetCurrentThreadId();
-#elif NACL_OSX
-  NaClSetCurrentMachThreadForThreadIndex(thread_idx);
-#endif
+  #if NACL_WINDOWS
+    nacl_thread_ids[thread_idx] = GetCurrentThreadId();
+  #elif NACL_OSX
+    NaClSetCurrentMachThreadForThreadIndex(thread_idx);
+  #endif
 
-  /*
-   * We have to hold the threads_mu and children_mu locks until
-   * after thread_num field in this thread has been initialized.
-   * All other threads can only find and examine this natp through
-   * the threads table, so the fact that natp is not consistent (no
-   * thread_num) will not be visible.
-   */
-  NaClXMutexLock(&nap->threads_mu);
-  NaClXMutexLock(&nap->children_mu);
-  nap->num_threads = thread_idx + 1;
-  natp->thread_num = thread_idx + 1;
-  if (!DynArraySet(&nap->threads, natp->thread_num, natp)) {
-    NaClLog(LOG_FATAL, "NaClAddThreadMu: DynArraySet at position %d failed\n", natp->thread_num);
+  if (tl_type != MAIN){
+      /*
+    * We have to hold the threads_mu and children_mu locks until
+    * after thread_num field in this thread has been initialized.
+    * All other threads can only find and examine this natp through
+    * the threads table, so the fact that natp is not consistent (no
+    * thread_num) will not be visible.
+    */
+    NaClXMutexLock(&nap->threads_mu);
+    NaClXMutexLock(&nap->children_mu);
+    nap->num_threads = thread_idx + 1;
+    natp->thread_num = thread_idx + 1;
+    if (!DynArraySet(&nap->threads, natp->thread_num, natp)) {
+      NaClLog(LOG_FATAL, "NaClAddThreadMu: DynArraySet at position %d failed\n", natp->thread_num);
+    }
+    NaClXMutexUnlock(&nap->threads_mu);
+    NaClXMutexUnlock(&nap->children_mu);
+
+    NaClVmHoleThreadStackIsSafe(natp->nap);
+
+    NaClStackSafetyNowOnUntrustedStack();
   }
-  NaClXMutexUnlock(&nap->threads_mu);
-  NaClXMutexUnlock(&nap->children_mu);
+  else {
+      /*
+    * We have to hold the threads_mu lock until after thread_num field
+    * in this thread has been initialized.  All other threads can only
+    * find and examine this natp through the threads table, so the fact
+    * that natp is not consistent (no thread_num) will not be visible.
+    */
+    NaClXMutexLock(&natp->nap->threads_mu);
+    natp->thread_num = NaClAddThreadMu(natp->nap, natp);
+    NaClXMutexUnlock(&natp->nap->threads_mu);
 
-  NaClVmHoleThreadStackIsSafe(natp->nap);
+    NaClVmHoleThreadStackIsSafe(natp->nap);
 
-  NaClStackSafetyNowOnUntrustedStack();
+    NaClStackSafetyNowOnUntrustedStack();
 
+  }
   /*
-   * Notify the debug stub, that a new thread is availible.
-   */
+    * Notify the debug stub, that a new thread is availible.
+    */
   if (natp->nap->debug_stub_callbacks) {
     natp->nap->debug_stub_callbacks->thread_create_hook(natp);
   }
 
-#if !NACL_WINDOWS
-  /*
-   * Ensure stack alignment.  Stack pointer must be -8 mod 16 when no
-   * __m256 objects are passed (8 mod 32 if __m256), after the call.
-   * Note the current doc (as of 2009-12-09) at
-   *
-   *   https://github.com/Lind-Project/native_client/raw/fork_implementation/documentation/x86-64_ABI.pdf
-   *
-   * is wrong since it claims (%rsp-8) should be 0 mod 16 or mod 32
-   * after the call, and it should be (%rsp+8) == 0 mod 16 or 32.
-   * Clearly it makes no difference since -8 and 8 are the same mod
-   * 16, but there is a difference when mod 32.
-   *
-   * This is not suitable for Windows because we do not reserve 32
-   * bytes for the shadow space.
-   */
-  secure_stack_ptr = NaClGetStackPtr();
-  NaClLog(1, "NaClStartThreadInApp: secure stack:   0x%"NACL_PRIxNACL_REG"\n",
-          secure_stack_ptr);
-  secure_stack_ptr = secure_stack_ptr & ~0x1f;
-  NaClLog(1, "NaClStartThreadInApp: adjusted stack: 0x%"NACL_PRIxNACL_REG"\n",
-          secure_stack_ptr);
-  natp->user.trusted_stack_ptr = secure_stack_ptr;
-#endif
+  if (tl_type != MAIN) {
+    #if !NACL_WINDOWS
+      /*
+      * Ensure stack alignment.  Stack pointer must be -8 mod 16 when no
+      * __m256 objects are passed (8 mod 32 if __m256), after the call.
+      * Note the current doc (as of 2009-12-09) at
+      *
+      *   https://github.com/Lind-Project/native_client/raw/fork_implementation/documentation/x86-64_ABI.pdf
+      *
+      * is wrong since it claims (%rsp-8) should be 0 mod 16 or mod 32
+      * after the call, and it should be (%rsp+8) == 0 mod 16 or 32.
+      * Clearly it makes no difference since -8 and 8 are the same mod
+      * 16, but there is a difference when mod 32.
+      *
+      * This is not suitable for Windows because we do not reserve 32
+      * bytes for the shadow space.
+      */
+      secure_stack_ptr = NaClGetStackPtr();
+      NaClLog(1, "NaClStartThreadInApp: secure stack:   0x%"NACL_PRIxNACL_REG"\n",
+              secure_stack_ptr);
+      secure_stack_ptr = secure_stack_ptr & ~0x1f;
+      NaClLog(1, "NaClStartThreadInApp: adjusted stack: 0x%"NACL_PRIxNACL_REG"\n",
+              secure_stack_ptr);
+      natp->user.trusted_stack_ptr = secure_stack_ptr;
+    #endif
 
-  NaClLog(1, "NaClStackThreadInApp: user stack: 0x%"NACL_PRIxPTR"\n",
-          NaClGetThreadCtxSp(context));
-  NaClLog(1, "%s\n", "NaClStartThreadInApp: switching to untrusted code");
+    NaClLog(1, "NaClStackThreadInApp: user stack: 0x%"NACL_PRIxPTR"\n",
+            NaClGetThreadCtxSp(context));
+    NaClLog(1, "%s\n", "NaClStartThreadInApp: switching to untrusted code");
 
-  NaClLog(1, "[NaClAppThreadLauncher] Nap %d is ready to launch! child registers: \n", nap->cage_id);
-  NaClLogThreadContext(natp);
-  NaClAppThreadPrintInfo(natp);
-  CHECK(thread_idx == nacl_user[thread_idx]->tls_idx);
+    NaClLog(1, "[NaClAppThreadLauncher] Nap %d is ready to launch! child registers: \n", nap->cage_id);
+    NaClLogThreadContext(natp);
+    NaClAppThreadPrintInfo(natp);
+    CHECK(thread_idx == nacl_user[thread_idx]->tls_idx);
 
-  /*
-   * After this NaClAppThreadSetSuspendState() call, we should not
-   * claim any mutexes, otherwise we risk deadlock.
-   */
-  NaClAppThreadSetSuspendState(natp, NACL_APP_THREAD_TRUSTED, NACL_APP_THREAD_UNTRUSTED);
-
-#if NACL_WINDOWS
-  /* This sets up a stack containing a return address that has unwind info. */
-  NaClSwitchSavingStackPtr(context, &context->trusted_stack_ptr, NaClSwitchToApp);
-#else
-  NaClSwitchToApp(natp);
-#endif
-}
-
-void WINAPI NaClAppThreadLauncher(void *state) {
-  struct NaClAppThread *natp = (struct NaClAppThread *) state;
-  uint32_t thread_idx;
-  NaClLog(4, "NaClAppThreadLauncher: entered\n");
-
-  NaClSignalStackRegister(natp->signal_stack);
-
-  NaClLog(4, "     natp  = 0x%016"NACL_PRIxPTR"\n", (uintptr_t)natp);
-  NaClLog(4, " prog_ctr  = 0x%016"NACL_PRIxNACL_REG"\n", natp->user.prog_ctr);
-  NaClLog(4, "stack_ptr  = 0x%016"NACL_PRIxPTR"\n",
-          NaClGetThreadCtxSp(&natp->user));
-
-  thread_idx = NaClGetThreadIdx(natp);
-  CHECK(0 < thread_idx);
-  CHECK(thread_idx < NACL_THREAD_MAX);
-  NaClTlsSetCurrentThread(natp);
-  nacl_user[thread_idx] = &natp->user;
-#if NACL_WINDOWS
-  nacl_thread_ids[thread_idx] = GetCurrentThreadId();
-#elif NACL_OSX
-  NaClSetCurrentMachThreadForThreadIndex(thread_idx);
-#endif
-
-  /*
-   * We have to hold the threads_mu lock until after thread_num field
-   * in this thread has been initialized.  All other threads can only
-   * find and examine this natp through the threads table, so the fact
-   * that natp is not consistent (no thread_num) will not be visible.
-   */
-  NaClXMutexLock(&natp->nap->threads_mu);
-  natp->thread_num = NaClAddThreadMu(natp->nap, natp);
-  NaClXMutexUnlock(&natp->nap->threads_mu);
-
-  NaClVmHoleThreadStackIsSafe(natp->nap);
-
-  NaClStackSafetyNowOnUntrustedStack();
-
-  /*
-   * Notify the debug stub, that a new thread is availible.
-   */
-  if (NULL != natp->nap->debug_stub_callbacks) {
-    natp->nap->debug_stub_callbacks->thread_create_hook(natp);
   }
 
-  /*
-   * After this NaClAppThreadSetSuspendState() call, we should not
-   * claim any mutexes, otherwise we risk deadlock.
-   */
-  NaClAppThreadSetSuspendState(natp, NACL_APP_THREAD_TRUSTED,
-                               NACL_APP_THREAD_UNTRUSTED);
+    /*
+    * After this NaClAppThreadSetSuspendState() call, we should not
+    * claim any mutexes, otherwise we risk deadlock.
+    */
+    NaClAppThreadSetSuspendState(natp, NACL_APP_THREAD_TRUSTED, NACL_APP_THREAD_UNTRUSTED);
 
-  NaClLog(1, "%s\n", "[NaCl Main Loader] User program about to start running inside the cage!");
-  NaClStartThreadInApp(natp, natp->user.prog_ctr);
+  /* Not exactly sure what hole exec falls into */
+  if (tl_type != MAIN) {
+    #if NACL_WINDOWS
+      /* This sets up a stack containing a return address that has unwind info. */
+      NaClSwitchSavingStackPtr(context, &context->trusted_stack_ptr, NaClSwitchToApp);
+    #else
+      NaClSwitchToApp(natp);
+    #endif
+  }
+  else {
+    NaClLog(1, "%s\n", "[NaCl Main Loader] User program about to start running inside the cage!");
+    NaClStartThreadInApp(natp, natp->user.prog_ctr);
+  }
 }
 
 static INLINE int GetChildIdx(const volatile sig_atomic_t *id_list, int nmemb, int cage_id) {
@@ -571,121 +545,176 @@ struct NaClAppThread *NaClAppThreadMake(struct NaClApp *nap,
   return NULL;
 }
 
-int NaClAppForkThreadSpawn(struct NaClApp           *nap_parent,
-                           struct NaClAppThread     *natp_parent,
-                           struct NaClApp           *nap_child,
-                           uintptr_t                usr_entry,
-                           uintptr_t                usr_stack_ptr,
-                           uint32_t                 user_tls1,
-                           uint32_t                 user_tls2) {
+
+
+int NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
+                              struct NaClAppThread     *natp_child,
+                              void *stack_ptr_parent,
+                              void *stack_ptr_child) {
+
+    size_t stack_ptr_offset;
+    size_t base_ptr_offset;
+    struct NaClApp *nap_parent = natp_parent->nap;
+    struct NaClApp *nap_child = natp_child->nap;
+    /* make a copy of parent and child thread context */
+
+    struct NaClThreadContext parent_ctx = natp_parent->user;  
+    struct NaClThreadContext child_ctx = natp_child->user;
+
+    stack_ptr_offset = parent_ctx.rsp - (uintptr_t)stack_ptr_parent;
+    base_ptr_offset = parent_ctx.rbp - (uintptr_t)stack_ptr_parent;
+    /* copy parent page tables and execution context */
+    NaClCopyExecutionContext(nap_parent, nap_child);
+    NaClLog(1, "fork_num: [%d], child cage_id: [%d], parent cage id: [%d]\n",
+            fork_num,
+            nap_child->cage_id,
+            nap_parent->cage_id);
+    NaClLog(1, "%s\n", "Thread context of child before copy");
+    NaClLogThreadContext(natp_child);
+    natp_child->user = natp_parent->user;
+    NaClLog(1, "%s\n", "Thread context of child after copy");
+    NaClLogThreadContext(natp_child);
+
+    /*
+    * adjust trampolines and %rip
+    */
+    nap_child->mem_start = child_ctx.r15;
+    natp_child->user.r15 = nap_child->mem_start;
+    natp_child->user.rsp = (uintptr_t)stack_ptr_child + stack_ptr_offset;
+    natp_child->user.rbp = (uintptr_t)stack_ptr_child + base_ptr_offset;
+    natp_child->user.sysret = 0;
+
+  /* examine arbitrary stack values */
+  #if defined(_DEBUG)
+  # define NUM_STACK_VALS 16
+  # define OUTPUT_FMT "0x%016lx"
+  # define TYPE_TO_EXAMINE uintptr_t
+  # define EXAMINE_ADDR(TYPE, FMT, ADDR)                                                             \
+          do {                                                                                       \
+            unsigned char *addr = (unsigned char *)(ADDR);                                           \
+            UNREFERENCED_PARAMETER(addr);                                                            \
+            NaClLog(2, "[Memory] Memory addr:                   %p\n", (void *)addr);                \
+            NaClLog(2, "[Memory] Memory content (byte-swapped): " FMT "\n", (TYPE)OBJ_REP_64(addr)); \
+            NaClLog(2, "[Memory] Memory content (raw):          " FMT "\n", *(TYPE *)addr);          \
+          } while (0)
+    for (size_t i = 0; i < NUM_STACK_VALS; i++) {
+      NaClLog(2, "child_stack[%zu]:\n", i);
+      EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, (TYPE_TO_EXAMINE *)stack_ptr_child + i);
+      NaClLog(2, "parent_stack[%zu]:\n", i);
+      EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, (TYPE_TO_EXAMINE *)stack_ptr_parent + i);
+    }
+    for (size_t i = 0; i < NUM_STACK_VALS; i++) {
+      uintptr_t child_addr = (uintptr_t)((TYPE_TO_EXAMINE *)natp_child->user.rsp + i);
+      uintptr_t parent_addr = (uintptr_t)((TYPE_TO_EXAMINE *)parent_ctx.rsp + i);
+      NaClLog(2, "child_rsp[%zu]:\n", i);
+      EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, child_addr);
+      NaClLog(2, "parent_rsp[%zu]:\n", i);
+      EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, parent_addr);
+    }
+  # undef NUM_STACK_VALS
+  # undef OUTPUT_FMT
+  # undef TYPE_TO_EXAMINE
+  # undef EXAMINE_ADDR
+  #endif /* defined(_DEBUG) */
+}
+
+int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
+                           struct NaClApp       *nap_child, 
+                           uintptr_t            stack_ptr){
+
+
   void *stack_ptr_parent;
   void *stack_ptr_child;
-  size_t stack_ptr_offset;
-  size_t base_ptr_offset;
+
   struct NaClAppThread *natp_child;
-  struct NaClThreadContext child_ctx;
-  struct NaClThreadContext parent_ctx;
+  struct NaClApp *nap_parent = natp_parent->nap;
+
+
   static THREAD int ignored_ret;
+
+  uintptr_t usr_stack_ptr;
+  uint32_t user_tls1;
+  uint32_t user_tls2;
+  enum NaClThreadLaunchType tl_type = nap_child->tl_type;
+
 
   if (!nap_parent->running) {
     return 0;
   }
 
-  NaClXMutexLock(&nap_parent->mu);
-  NaClXMutexLock(&nap_child->mu);
+  if (tl_type != MAIN) {
+    NaClXMutexLock(&nap_parent->mu);
+    NaClXMutexLock(&nap_child->mu);
 
-  /* guard against extra spawned instances */
-  if (nap_child->in_fork) {
+    /* guard against extra spawned instances */
+    if (nap_child->in_fork) {
     goto already_running;
+    }
+    nap_child->in_fork = 1;
   }
-  nap_child->in_fork = 1;
 
-  /* make a copy of parent thread context */
-  parent_ctx = natp_parent->user;
 
   /*
    * make space to copy the parent stack
    */
+  uintptr_t usr_entry =   nap_child->initial_entry_pt;
+  if (tl_type == MAIN){
+    /* Google suggested starting addresses */
+    user_tls1 = (uint32_t) nap_child->break_addr;
+    user_tls2 = 0;
+  }
+  else {
+    user_tls1 = (uint32_t)natp_parent->user.tls_value1;
+    user_tls2 = (uint32_t)natp_parent->user.tls_value2);
+  }
+
+
   nap_child->stack_size = nap_parent->stack_size;
   stack_ptr_parent = (void *)NaClUserToSysAddr(nap_parent, NaClGetInitialStackTop(nap_parent));
   stack_ptr_child = (void *)NaClUserToSysAddr(nap_child, NaClGetInitialStackTop(nap_child));
-  stack_ptr_offset = parent_ctx.rsp - (uintptr_t)stack_ptr_parent;
-  base_ptr_offset = parent_ctx.rbp - (uintptr_t)stack_ptr_parent;
-  usr_stack_ptr = NaClSysToUserStackAddr(nap_child, (uintptr_t)stack_ptr_child);
+  
+  /* Set stack ptr according to thread type */
+  if (tl_type == FORK) usr_stack_ptr = NaClSysToUserStackAddr(nap_child, (uintptr_t)stack_ptr_child);
+  else usr_stack_ptr = NaClSysToUserStackAddr(nap_child, stack_ptr);
+
+  /* Make new/child thread natp */
   natp_child = NaClAppThreadMake(nap_child, usr_entry, usr_stack_ptr, user_tls1, user_tls2);
 
   if (!natp_child) {
     return 0;
   }
 
-  /* copy parent page tables and execution context */
-  child_ctx = natp_child->user;
-  NaClCopyExecutionContext(nap_parent, nap_child);
-  NaClLog(1, "fork_num: [%d], child cage_id: [%d], parent cage id: [%d]\n",
-          fork_num,
-          nap_child->cage_id,
-          nap_parent->cage_id);
-  NaClLog(1, "%s\n", "Thread context of child before copy");
-  NaClLogThreadContext(natp_child);
-  natp_child->user = natp_parent->user;
-  NaClLog(1, "%s\n", "Thread context of child after copy");
-  NaClLogThreadContext(natp_child);
+  /* Create context for master, or use loaded contexts to setup fork */
+  if (tl_type == MAIN){
+    /*
+    * save master thread context pointer
+    */
+    if (nap_child->cage_id == 1 || !master_ctx) {
+      master_ctx = &natp->user;
+    }
+    nap_child->parent = NULL;
+    nap_child->master = ((struct NaClAppThread *)master_ctx)->nap;
+  }
+  else if (tl_type == FORK) {
+    NaClForkThreadContextSetup(natp_parent, natp_child, stack_ptr_parent, stack_ptr_child);
+  }
+ 
 
   /*
-   * adjust trampolines and %rip
+   * setup TLS slot in the global nacl_user array for Fork/Exec
    */
-  nap_child->mem_start = child_ctx.r15;
-  natp_child->user.r15 = nap_child->mem_start;
-  natp_child->user.rsp = (uintptr_t)stack_ptr_child + stack_ptr_offset;
-  natp_child->user.rbp = (uintptr_t)stack_ptr_child + base_ptr_offset;
-  natp_child->user.sysret = 0;
-
-/* examine arbitrary stack values */
-#if defined(_DEBUG)
-# define NUM_STACK_VALS 16
-# define OUTPUT_FMT "0x%016lx"
-# define TYPE_TO_EXAMINE uintptr_t
-# define EXAMINE_ADDR(TYPE, FMT, ADDR)                                                             \
-        do {                                                                                       \
-          unsigned char *addr = (unsigned char *)(ADDR);                                           \
-          UNREFERENCED_PARAMETER(addr);                                                            \
-          NaClLog(2, "[Memory] Memory addr:                   %p\n", (void *)addr);                \
-          NaClLog(2, "[Memory] Memory content (byte-swapped): " FMT "\n", (TYPE)OBJ_REP_64(addr)); \
-          NaClLog(2, "[Memory] Memory content (raw):          " FMT "\n", *(TYPE *)addr);          \
-        } while (0)
-  for (size_t i = 0; i < NUM_STACK_VALS; i++) {
-    NaClLog(2, "child_stack[%zu]:\n", i);
-    EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, (TYPE_TO_EXAMINE *)stack_ptr_child + i);
-    NaClLog(2, "parent_stack[%zu]:\n", i);
-    EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, (TYPE_TO_EXAMINE *)stack_ptr_parent + i);
+  if (tl_type != MAIN) {
+    natp_child->user.tls_idx = nap_child->cage_id;
+    if (nacl_user[natp_child->user.tls_idx]) {
+      NaClLog(1, "nacl_user[%u] not NULL (%p)\n)",
+              natp_child->user.tls_idx,
+              (void *)nacl_user[natp_child->user.tls_idx]);
+      goto already_running;
+    }
+    nacl_user[natp_child->user.tls_idx] = &natp_child->user;
+    NaClTlsSetTlsValue1(natp_child, user_tls1);
+    NaClTlsSetTlsValue2(natp_child, user_tls2);
   }
-  for (size_t i = 0; i < NUM_STACK_VALS; i++) {
-    uintptr_t child_addr = (uintptr_t)((TYPE_TO_EXAMINE *)natp_child->user.rsp + i);
-    uintptr_t parent_addr = (uintptr_t)((TYPE_TO_EXAMINE *)parent_ctx.rsp + i);
-    NaClLog(2, "child_rsp[%zu]:\n", i);
-    EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, child_addr);
-    NaClLog(2, "parent_rsp[%zu]:\n", i);
-    EXAMINE_ADDR(TYPE_TO_EXAMINE, OUTPUT_FMT, parent_addr);
-  }
-# undef NUM_STACK_VALS
-# undef OUTPUT_FMT
-# undef TYPE_TO_EXAMINE
-# undef EXAMINE_ADDR
-#endif /* defined(_DEBUG) */
-
-  /*
-   * setup TLS slot in the global nacl_user array
-   */
-  natp_child->user.tls_idx = nap_child->cage_id;
-  if (nacl_user[natp_child->user.tls_idx]) {
-    NaClLog(1, "nacl_user[%u] not NULL (%p)\n)",
-            natp_child->user.tls_idx,
-            (void *)nacl_user[natp_child->user.tls_idx]);
-    goto already_running;
-  }
-  nacl_user[natp_child->user.tls_idx] = &natp_child->user;
-  NaClTlsSetTlsValue1(natp_child, user_tls1);
-  NaClTlsSetTlsValue2(natp_child, user_tls2);
 
   /*
    * We set host_thread_is_defined assuming, for now, that
@@ -693,15 +722,19 @@ int NaClAppForkThreadSpawn(struct NaClApp           *nap_parent,
    */
   natp_child->host_thread_is_defined = 1;
 
-  NaClXCondVarBroadcast(&nap_parent->cv);
-  NaClXMutexUnlock(&nap_parent->mu);
-  NaClXMutexUnlock(&nap_child->mu);
+  if (tl_type != MAIN){
+    NaClXCondVarBroadcast(&nap_parent->cv);
+    NaClXMutexUnlock(&nap_parent->mu);
+    NaClXMutexUnlock(&nap_child->mu);
 
-  /* TODO: figure out a better way to avoid extra instance spawns -jp */
-  NaClThreadYield();
-  NaClXMutexLock(&nap_child->mu);
-  nap_child->in_fork = 0;
-  NaClXMutexUnlock(&nap_child->mu);
+    /* TODO: figure out a better way to avoid extra instance spawns -jp */
+    NaClThreadYield();
+    NaClXMutexLock(&nap_child->mu);
+    nap_child->in_fork = 0;
+    NaClXMutexUnlock(&nap_child->mu);
+  }
+
+
 
   if (!NaClThreadCtor(&natp_child->host_thread, NaClAppForkThreadLauncher, natp_child, NACL_KERN_STACK_SIZE)) {
     /*
@@ -721,46 +754,6 @@ already_running:
     NaClXMutexUnlock(&nap_parent->mu);
     NaClXMutexUnlock(&nap_child->mu);
     pthread_exit(&ignored_ret);
-}
-
-int NaClAppThreadSpawn(struct NaClApp *nap,
-                       uintptr_t      usr_entry,
-                       uintptr_t      usr_stack_ptr,
-                       uint32_t       user_tls1,
-                       uint32_t       user_tls2) {
-  struct NaClAppThread *natp = NaClAppThreadMake(nap, usr_entry, usr_stack_ptr,
-                                                 user_tls1, user_tls2);
-
-  if (!natp) {
-    return 0;
-  }
-
-  /*
-   * save master thread context pointer
-   */
-  if (nap->cage_id == 1 || !master_ctx) {
-    master_ctx = &natp->user;
-  }
-  nap->parent = NULL;
-  nap->master = ((struct NaClAppThread *)master_ctx)->nap;
-
-  /*
-   * We set host_thread_is_defined assuming, for now, that
-   * NaClThreadCtor() will succeed.
-   */
-  natp->host_thread_is_defined = 1;
-  if (!NaClThreadCtor(&natp->host_thread, NaClAppThreadLauncher, (void *) natp,
-                      NACL_KERN_STACK_SIZE)) {
-    /*
-     * No other thread saw the NaClAppThread, so it is OK that
-     * host_thread was not initialized despite host_thread_is_defined
-     * being set.
-     */
-    natp->host_thread_is_defined = 0;
-    NaClAppThreadDelete(natp);
-    return 0;
-  }
-  return 1;
 }
 
 /*

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -160,7 +160,7 @@ void NaClAppThreadTeardown(struct NaClAppThread *natp);
 /*
  * Handles fork specific setup in thread spawning, specific to context
  */
-int NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
+void NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
                               struct NaClAppThread     *natp_child,
                               void *stack_ptr_parent,
                               void *stack_ptr_child);

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -152,11 +152,18 @@ struct NaClAppThread {
 
 struct NaClApp *NaClChildNapCtor(struct NaClApp *nap);
 
-void WINAPI NaClAppForkThreadLauncher(void *state);
 void WINAPI NaClAppThreadLauncher(void *state);
 
 void NaClAppThreadTeardown(struct NaClAppThread *natp);
 
+
+/*
+ * Handles fork specific setup in thread spawning, specific to context
+ */
+int NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
+                              struct NaClAppThread     *natp_child,
+                              void *stack_ptr_parent,
+                              void *stack_ptr_child);
 /*
  * NaClAppThreadMake() creates a NaClAppThread object without invoking
  * untrusted code or creating a host thread.
@@ -176,19 +183,10 @@ struct NaClAppThread *NaClAppThreadMake(struct NaClApp *nap,
  * thread that invokes the given entry point in untrusted code.  This
  * returns true on success, false on failure.
  */
-int NaClAppThreadSpawn(struct NaClApp *nap,
-                       uintptr_t      usr_entry,
-                       uintptr_t      usr_stack_ptr,
-                       uint32_t       user_tls1,
-                       uint32_t       user_tls2) NACL_WUR;
+int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
+                           struct NaClApp       *nap_child, 
+                           uintptr_t            stack_ptr) NACL_WUR;
 
-int NaClAppForkThreadSpawn(struct NaClApp           *nap_parent,
-                           struct NaClAppThread     *natp_parent,
-                           struct NaClApp           *nap_child,
-                           uintptr_t                usr_entry,
-                           uintptr_t                usr_stack_ptr,
-                           uint32_t                 user_tls1,
-                           uint32_t                 user_tls2) NACL_WUR;
 
 void NaClAppThreadDelete(struct NaClAppThread *natp);
 

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -184,8 +184,11 @@ struct NaClAppThread *NaClAppThreadMake(struct NaClApp *nap,
  * returns true on success, false on failure.
  */
 int NaClAppThreadSpawn(struct NaClAppThread     *natp_parent,
-                           struct NaClApp       *nap_child, 
-                           uintptr_t            stack_ptr) NACL_WUR;
+                       struct NaClApp           *nap_child,
+                       uintptr_t                usr_entry,
+                       uintptr_t                usr_stack_ptr,
+                       uint32_t                 user_tls1,
+                       uint32_t                 user_tls2) NACL_WUR;
 
 
 void NaClAppThreadDelete(struct NaClAppThread *natp);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4034,7 +4034,7 @@ int32_t NaClSysFork(struct NaClAppThread *natp) {
   NaClXMutexUnlock(&nap->mu);
 
   /* start fork thread */
-  if (!NaClCreateMainForkThread(natp, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+  if (!NaClCreateThread(FORK, natp, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
     NaClLog(1, "%s\n", "[NaClSysFork] forking program failed!");
     ret = -NACL_ABI_ENOMEM;
     goto fail;
@@ -4312,8 +4312,8 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   /* execute new binary */
   ret = -NACL_ABI_ENOEXEC;
   NaClLog(1, "binary = %s\n", nap->binary);
-  if (!NaClCreateMainThread(nap_child, child_argc, child_argv, nap_child->clean_environ)) {
-    NaClLog(LOG_ERROR, "%s\n", "NaClCreateMainForkThread() failed");
+  if (!NaClCreateThread(EXEC, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+    NaClLog(LOG_ERROR, "%s\n", "NaClCreateThread() failed");
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;
   }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4317,20 +4317,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;
   }
-  
-  /* 
-   * TODO
-   * The following line is a quick-patch to get Bash to work minimally 
-   * The use of CreateMainThread above mistakenly gets rid of the child parent reference,
-   * but using the Fork version of the function makes other changes that inhibits the new 
-   * program from exec'ing. We'll use this fix for now so we can merge the structural changes into master
-   * and the larger issue will be resolved in the upcoming refactor.
-   */
-  
-  nap_child->parent = nap;
-
-  
-  
+    
   /* wait for child to finish before cleaning up */
   NaClWaitForMainThreadToExit(nap_child);
   NaClReportExitStatus(nap, nap_child->exit_status);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4034,7 +4034,7 @@ int32_t NaClSysFork(struct NaClAppThread *natp) {
   NaClXMutexUnlock(&nap->mu);
 
   /* start fork thread */
-  if (!NaClCreateThread(FORK, natp, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+  if (!NaClCreateThread(THREAD_LAUNCH_FORK, natp, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
     NaClLog(1, "%s\n", "[NaClSysFork] forking program failed!");
     ret = -NACL_ABI_ENOMEM;
     goto fail;
@@ -4312,7 +4312,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   /* execute new binary, we pass NULL as parent natp since we're not basing the new thread off of this one. */
   ret = -NACL_ABI_ENOEXEC;
   NaClLog(1, "binary = %s\n", nap->binary);
-  if (!NaClCreateThread(EXEC, NULL, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+  if (!NaClCreateThread(THREAD_LAUNCH_EXEC, NULL, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
     NaClLog(LOG_ERROR, "%s\n", "NaClCreateThread() failed");
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4309,10 +4309,10 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   NaClXMutexUnlock(&nap_child->mu);
   NaClXMutexUnlock(&nap->mu);
 
-  /* execute new binary */
+  /* execute new binary, we pass NULL as parent natp since we're not basing the new thread off of this one. */
   ret = -NACL_ABI_ENOEXEC;
   NaClLog(1, "binary = %s\n", nap->binary);
-  if (!NaClCreateThread(EXEC, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+  if (!NaClCreateThread(EXEC, NULL, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
     NaClLog(LOG_ERROR, "%s\n", "NaClCreateThread() failed");
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -114,6 +114,12 @@ struct NaClSpringboardInfo {
   uint32_t end_addr;
 };
 
+enum NaClThreadLaunchType {
+  MAIN,
+  FORK,
+  EXEC
+};
+
 struct NaClApp {
   /*
    * children table lock children_mu is higher in the locking order than
@@ -134,6 +140,7 @@ struct NaClApp {
   volatile sig_atomic_t     cage_id;
   volatile sig_atomic_t     num_lib;
   volatile sig_atomic_t     parent_id;
+  enum NaClThreadLaunchType tl_type;
 
   /* yiwen: store the path of the execuable running inside this cage(as the main thread) */
   int                       argc;
@@ -633,16 +640,14 @@ uintptr_t NaClGetInitialStackTop(struct NaClApp *nap);
  * alternative design, NaClWaitForMainThreadToExit will become a
  * no-op.
  */
-int NaClCreateMainThread(struct NaClApp     *nap,
-                         int                argc,
-                         char               **argv,
-                         char const *const  *envv) NACL_WUR;
 
-int NaClCreateMainForkThread(struct NaClAppThread     *natp_parent,
-                             struct NaClApp           *nap_child,
-                             int                      argc,
-                             char                     **argv,
-                             char const *const        *envv) NACL_WUR;
+
+int NaClCreateThread(enum NaClThreadLaunchType tl_type,
+                     struct NaClAppThread     *natp_parent,
+                     struct NaClApp           *nap_child,
+                     int                      argc,
+                     char                     **argv,
+                     char const *const        *envv) NACL_WUR;
 
 int NaClWaitForMainThreadToExit(struct NaClApp  *nap);
 

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -115,9 +115,9 @@ struct NaClSpringboardInfo {
 };
 
 enum NaClThreadLaunchType {
-  MAIN,
-  FORK,
-  EXEC
+  THREAD_LAUNCH_MAIN,
+  THREAD_LAUNCH_FORK,
+  THREAD_LAUNCH_EXEC
 };
 
 struct NaClApp {

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -713,7 +713,7 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
   nap_child->tl_type = tl_type;
 
 
-  if (tl_type == FORK){
+  if (tl_type == THREAD_LAUNCH_FORK){
 
     nap_parent = natp_parent->nap;
 
@@ -885,8 +885,8 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
     and send out CV's for FORK/EXEC
   */
 
-  if (tl_type != FORK)  NaClXMutexLock(&nap_child->mu);
-  if (tl_type != MAIN)  NaClXCondVarBroadcast(&nap_child->cv);
+  if (tl_type != THREAD_LAUNCH_FORK)  NaClXMutexLock(&nap_child->mu);
+  if (tl_type != THREAD_LAUNCH_MAIN)  NaClXCondVarBroadcast(&nap_child->cv);
 
   nap_child->running = 1;
   NaClXMutexUnlock(&nap_child->mu);
@@ -909,7 +909,7 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
   NaClLog(1, "   initial entry pt : %016"NACL_PRIxPTR"\n", nap_child->initial_entry_pt);
   NaClLog(1, "      user entry pt : %016"NACL_PRIxPTR"\n", nap_child->user_entry_pt);
 
-  if (tl_type != MAIN){
+  if (tl_type != THREAD_LAUNCH_MAIN){
     /* TODO: figure out a better way to avoid extra instance spawns -jp */
     NaClThreadYield();
     NaClXMutexLock(&nap_child->mu);
@@ -929,7 +929,7 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
    */
   uint32_t user_tls1;
   uint32_t user_tls2;
-  if (tl_type != FORK){
+  if (tl_type != THREAD_LAUNCH_FORK){
     /* Google suggested starting addresses */
     user_tls1 = (uint32_t) nap_child->break_addr;
     user_tls2 = 0;
@@ -945,7 +945,7 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
 cleanup:
   free(argv_len);
   free(envv_len);
-  if (tl_type == FORK) NaClXMutexUnlock(&nap_child->mu);
+  if (tl_type == THREAD_LAUNCH_FORK) NaClXMutexUnlock(&nap_child->mu);
 
   return retval;
 
@@ -986,7 +986,7 @@ int32_t NaClCreateAdditionalThread(struct NaClApp *nap,
                                    uint32_t       user_tls2) {
 
   /* We need to set the thread type for the thread mechanics */
-  nap->tl_type = MAIN;
+  nap->tl_type = THREAD_LAUNCH_MAIN;
 
   if (!NaClAppThreadSpawn(NULL,
                           nap,

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -929,7 +929,7 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
    */
   uint32_t user_tls1;
   uint32_t user_tls2;
-  if (tl_type == MAIN){
+  if (tl_type != MAIN){
     /* Google suggested starting addresses */
     user_tls1 = (uint32_t) nap_child->break_addr;
     user_tls2 = 0;

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -929,7 +929,7 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
    */
   uint32_t user_tls1;
   uint32_t user_tls2;
-  if (tl_type != MAIN){
+  if (tl_type != FORK){
     /* Google suggested starting addresses */
     user_tls1 = (uint32_t) nap_child->break_addr;
     user_tls2 = 0;

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -927,7 +927,6 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
   /*
    * make space to copy the parent stack
    */
-  uintptr_t usr_entry =  ;
   uint32_t user_tls1;
   uint32_t user_tls2;
   if (tl_type == MAIN){

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -841,10 +841,11 @@ int NaClSelLdrMain(int argc, char **argv) {
   NaClLog(1, "%s\n\n", "[NaCl Main Loader] before creation of the cage to run user program!");
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
   nacl_initialization_finish = clock();
-  if (!NaClCreateMainThread(nap,
-                            argc - optind,
-                            argv + optind,
-                            nap->clean_environ)) {
+  if (!NaClCreateThread(MAIN,
+                        nap,
+                        argc - optind,
+                        argv + optind,
+                        nap->clean_environ)) {
     NaClLog(LOG_ERROR, "%s\n", "creating main thread failed");
     goto done;
   }

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -841,7 +841,7 @@ int NaClSelLdrMain(int argc, char **argv) {
   NaClLog(1, "%s\n\n", "[NaCl Main Loader] before creation of the cage to run user program!");
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
   nacl_initialization_finish = clock();
-  if (!NaClCreateThread(MAIN,
+  if (!NaClCreateThread(THREAD_LAUNCH_MAIN,
                         NULL,
                         nap,
                         argc - optind,

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -842,6 +842,7 @@ int NaClSelLdrMain(int argc, char **argv) {
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
   nacl_initialization_finish = clock();
   if (!NaClCreateThread(MAIN,
+                        NULL,
                         nap,
                         argc - optind,
                         argv + optind,

--- a/src/trusted/service_runtime/sel_main_chrome.c
+++ b/src/trusted/service_runtime/sel_main_chrome.c
@@ -356,7 +356,7 @@ void NaClChromeMainStart(struct NaClChromeMainArgs *args) {
 
   if (NACL_FI_ERROR_COND(
           "NaClCreateThread",
-          !NaClCreateThread(MAIN, NULL, nap, ac, av,
+          !NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, nap, ac, av,
                                 NaClEnvCleanserEnvironment(&env_cleanser)))) {
     NaClLog(LOG_FATAL, "creating main thread failed\n");
   }

--- a/src/trusted/service_runtime/sel_main_chrome.c
+++ b/src/trusted/service_runtime/sel_main_chrome.c
@@ -356,7 +356,7 @@ void NaClChromeMainStart(struct NaClChromeMainArgs *args) {
 
   if (NACL_FI_ERROR_COND(
           "CreateMainThread",
-          !NaClCreateMainThread(nap, ac, av,
+          !NaClCreateThread(MAIN, NULL, nap, ac, av,
                                 NaClEnvCleanserEnvironment(&env_cleanser)))) {
     NaClLog(LOG_FATAL, "creating main thread failed\n");
   }

--- a/src/trusted/service_runtime/sel_main_chrome.c
+++ b/src/trusted/service_runtime/sel_main_chrome.c
@@ -355,7 +355,7 @@ void NaClChromeMainStart(struct NaClChromeMainArgs *args) {
   args = NULL;
 
   if (NACL_FI_ERROR_COND(
-          "CreateMainThread",
+          "NaClCreateThread",
           !NaClCreateThread(MAIN, NULL, nap, ac, av,
                                 NaClEnvCleanserEnvironment(&env_cleanser)))) {
     NaClLog(LOG_FATAL, "creating main thread failed\n");

--- a/tests/custom_desc/desc_test_host.c
+++ b/tests/custom_desc/desc_test_host.c
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
   NaClSetDesc(&app, 10, g_expected_desc);
 
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   /* Check for leaks. */

--- a/tests/custom_desc/desc_test_host.c
+++ b/tests/custom_desc/desc_test_host.c
@@ -196,7 +196,7 @@ int main(int argc, char **argv) {
   NaClSetDesc(&app, 10, g_expected_desc);
 
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateMainThread(&app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   /* Check for leaks. */

--- a/tests/faulted_thread_queue/faultqueue_test_host.c
+++ b/tests/faulted_thread_queue/faultqueue_test_host.c
@@ -105,7 +105,7 @@ struct NaClSignalContext *StartGuestWithSharedMemory(
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateMainThread(MAIN, NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
   return expected_regs;
 }
 

--- a/tests/faulted_thread_queue/faultqueue_test_host.c
+++ b/tests/faulted_thread_queue/faultqueue_test_host.c
@@ -105,7 +105,7 @@ struct NaClSignalContext *StartGuestWithSharedMemory(
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateThread(MAIN, NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
   return expected_regs;
 }
 

--- a/tests/faulted_thread_queue/faultqueue_test_host.c
+++ b/tests/faulted_thread_queue/faultqueue_test_host.c
@@ -105,7 +105,7 @@ struct NaClSignalContext *StartGuestWithSharedMemory(
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateMainThread(nap, NACL_ARRAY_SIZE(args), args, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
   return expected_regs;
 }
 

--- a/tests/minnacl/minimal_test_host.c
+++ b/tests/minnacl/minimal_test_host.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
   /* These are examples of two different ways to run untrusted code. */
   if (use_separate_thread) {
     /* Create a new host thread that is managed by NaCl. */
-    CHECK(NaClCreateMainThread(&app, 0, NULL, NULL));
+    CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
     NaClWaitForMainThreadToExit(&app);
 
     NaClLog(LOG_FATAL, "The exit syscall is not supposed to be callable\n");

--- a/tests/minnacl/minimal_test_host.c
+++ b/tests/minnacl/minimal_test_host.c
@@ -73,7 +73,7 @@ int main(int argc, char **argv) {
   /* These are examples of two different ways to run untrusted code. */
   if (use_separate_thread) {
     /* Create a new host thread that is managed by NaCl. */
-    CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
+    CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
     NaClWaitForMainThreadToExit(&app);
 
     NaClLog(LOG_FATAL, "The exit syscall is not supposed to be callable\n");

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[0], handle_pair[0], SEND_DESC);
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
-  CHECK(NaClCreateMainThread(&app[0], 2, domain1_args, NULL));
-  CHECK(NaClCreateMainThread(&app[1], 2, domain2_args, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app[0], 2, domain1_args, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app[1], 2, domain2_args, NULL));
 
   return_code = NaClWaitForMainThreadToExit(&app[0]);
   CHECK(return_code == 101);

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[0], handle_pair[0], SEND_DESC);
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
-  CHECK(NaClCreateThread(MAIN, NULL, &app[0], 2, domain1_args, NULL));
-  CHECK(NaClCreateThread(MAIN, NULL, &app[1], 2, domain2_args, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app[0], 2, domain1_args, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app[1], 2, domain2_args, NULL));
 
   return_code = NaClWaitForMainThreadToExit(&app[0]);
   CHECK(return_code == 101);

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[0], handle_pair[0], SEND_DESC);
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app[0], 2, domain1_args, NULL));
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app[1], 2, domain2_args, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app[0], 2, domain1_args, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app[1], 2, domain2_args, NULL));
 
   return_code = NaClWaitForMainThreadToExit(&app[0]);
   CHECK(return_code == 101);

--- a/tests/signal_handler_single_step/regs_step_test_host.c
+++ b/tests/signal_handler_single_step/regs_step_test_host.c
@@ -337,7 +337,7 @@ int main(int argc, char **argv) {
   g_test_shm = (struct RegsTestShm *) NaClUserToSys(&app, mmap_addr);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
 
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 2, args, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app, 2, args, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/regs_step_test_host.c
+++ b/tests/signal_handler_single_step/regs_step_test_host.c
@@ -337,7 +337,7 @@ int main(int argc, char **argv) {
   g_test_shm = (struct RegsTestShm *) NaClUserToSys(&app, mmap_addr);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
 
-  CHECK(NaClCreateThread(MAIN, NULL, &app, 2, args, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 2, args, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/regs_step_test_host.c
+++ b/tests/signal_handler_single_step/regs_step_test_host.c
@@ -337,7 +337,7 @@ int main(int argc, char **argv) {
   g_test_shm = (struct RegsTestShm *) NaClUserToSys(&app, mmap_addr);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
 
-  CHECK(NaClCreateMainThread(&app, 2, args, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 2, args, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateMainThread(&app, 0, NULL, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -171,7 +171,7 @@ int main(int argc, char **argv) {
 
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/thread_suspension/suspend_test_host.c
+++ b/tests/thread_suspension/suspend_test_host.c
@@ -85,7 +85,7 @@ static struct SuspendTestShm *StartGuestWithSharedMemory(
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateMainThread(nap, 3, args, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, nap, 3, args, NULL));
   return (struct SuspendTestShm *) NaClUserToSys(nap, mmap_addr);
 }
 

--- a/tests/thread_suspension/suspend_test_host.c
+++ b/tests/thread_suspension/suspend_test_host.c
@@ -85,7 +85,7 @@ static struct SuspendTestShm *StartGuestWithSharedMemory(
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateThread(MAIN, NULL, nap, 3, args, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, nap, 3, args, NULL));
   return (struct SuspendTestShm *) NaClUserToSys(nap, mmap_addr);
 }
 

--- a/tests/thread_suspension/suspend_test_host.c
+++ b/tests/thread_suspension/suspend_test_host.c
@@ -85,7 +85,7 @@ static struct SuspendTestShm *StartGuestWithSharedMemory(
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateMainThread(MAIN, NULL, nap, 3, args, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, nap, 3, args, NULL));
   return (struct SuspendTestShm *) NaClUserToSys(nap, mmap_addr);
 }
 

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 
   RegisterHandlers();
 
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app, argc - 1, argv + 1, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app, argc - 1, argv + 1, NULL));
   NaClWaitForMainThreadToExit(&app);
 
   NaClLog(LOG_ERROR, "We did not expect the test program to exit cleanly\n");

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 
   RegisterHandlers();
 
-  CHECK(NaClCreateThread(MAIN, NULL, &app, argc - 1, argv + 1, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, argc - 1, argv + 1, NULL));
   NaClWaitForMainThreadToExit(&app);
 
   NaClLog(LOG_ERROR, "We did not expect the test program to exit cleanly\n");

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 
   RegisterHandlers();
 
-  CHECK(NaClCreateMainThread(&app, argc - 1, argv + 1, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app, argc - 1, argv + 1, NULL));
   NaClWaitForMainThreadToExit(&app);
 
   NaClLog(LOG_ERROR, "We did not expect the test program to exit cleanly\n");

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
   RegisterExceptionHandler();
 
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
   NaClWaitForMainThreadToExit(&app);
   NaClLog(LOG_FATAL, "Did not expect the guest code to exit\n");
   return 1;

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
   RegisterExceptionHandler();
 
-  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
   NaClWaitForMainThreadToExit(&app);
   NaClLog(LOG_FATAL, "Did not expect the guest code to exit\n");
   return 1;

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
   RegisterExceptionHandler();
 
-  CHECK(NaClCreateMainThread(&app, 0, NULL, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 0, NULL, NULL));
   NaClWaitForMainThreadToExit(&app);
   NaClLog(LOG_FATAL, "Did not expect the guest code to exit\n");
   return 1;

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
   app.enable_exception_handling = 1;
   CHECK(NaClAppLoadFileFromFilename(&app, argv[2]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   if (g_expect_crash) {

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
   app.enable_exception_handling = 1;
   CHECK(NaClAppLoadFileFromFilename(&app, argv[2]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateMainThread(&app, 0, NULL, NULL));
+  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   if (g_expect_crash) {

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -157,7 +157,7 @@ int main(int argc, char **argv) {
   app.enable_exception_handling = 1;
   CHECK(NaClAppLoadFileFromFilename(&app, argv[2]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateMainThread(MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(MAIN, NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   if (g_expect_crash) {


### PR DESCRIPTION
This PR consolidates our threading pipeline.

I've created an option that lives inside the nap that indicates which thread-type (MAIN, FORK, or EXEC) were launching and are able to set that accordingly.

This moves ThreadCreate, ThreadSpawn, and ThreadLauncher all into one consolidated function instead of one each for fork and main.

Most of the important changes here are in nacl_app_thread.c and sel_ldr_std.c as well as a few in nacl_syscall_common.c. A bunch of the changed files are just updating the native client test files to include the new thread syntax.

I probably, like always, need better comments here. Please let me know anything that's unclear.