### PR TITLE
Fd and dup updates

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -788,3 +788,10 @@ int lind_fork(int newcageid, int cageid){
     LIND_API_PART2;
     LIND_API_PART3;
 }
+
+int lind_exec(int newcageid, int cageid){
+    LIND_API_PART1;
+    callArgs = Py_BuildValue("(i[ii])", LIND_safe_fs_exec, newcageid, cageid);
+    LIND_API_PART2;
+    LIND_API_PART3;
+}

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -82,9 +82,12 @@
 #define LIND_safe_fs_flock              54
 #define LIND_safe_fs_rename             55
 
-#define LIND_safe_fs_pipe              66
-#define LIND_safe_fs_pipe2             67
+#define LIND_safe_fs_pipe               66
+#define LIND_safe_fs_pipe2              67
 #define LIND_safe_fs_fork               68
+#define LIND_safe_fs_exec               69
+
+
 
 #define LIND_comp_cia                   105
 #define LIND_comp_call                  106

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -61,7 +61,7 @@
 #define LIND_safe_net_bind              33
 #define LIND_safe_net_send              34
 #define LIND_safe_net_sendto            35
-#define LIND_safe_net_recv              362
+#define LIND_safe_net_recv              36
 #define LIND_safe_net_recvfrom          37
 #define LIND_safe_net_connect           38
 #define LIND_safe_net_listen            39

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -159,5 +159,7 @@ int lind_flock (int fd, int operation);
 int lind_pipe(int* pipefds, int cageid);
 int lind_pipe2(int* pipefds, int flags, int cageid);  /* unimplemented */
 int lind_fork(int newcageid, int cageid);
+int lind_exec(int newcageid, int cageid);
+
 
 #endif /* LIND_PLATFORM_H_ */

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -146,12 +146,13 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
   
   /* duplicate file descriptor table starting at child_fd = 3 (0-2 setup previously)*/
   NaClXMutexLock(&nap_parent->mu);
-  for (int parent_fd = 0; parent_fd <= FILE_DESC_MAX; parent_fd++) {
+
+  for (int fd = 0; fd <= FILE_DESC_MAX; fd++) {
 
     /* Retrive the host fd we had stored in the Cage Table for the parent */
-    int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];
+    int parent_host_fd = fd_cage_table[nap_parent->cage_id][fd];
     if (parent_host_fd == -1) {
-      fd_cage_table[nap_child->cage_id][nap_child->fd++] = -1;
+      fd_cage_table[nap_child->cage_id][fd] = -1;
       continue;
     }
     /* Retrieve Parent NaCl Descriptor based on current child fd in the parent */
@@ -183,10 +184,10 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     NaClSetDesc(nap_parent, parent_host_fd, parent_nd);
 
     /* Set childs cage table with the current fd to the old parent host fd */
-    fd_cage_table[nap_child->cage_id][nap_child->fd++] = child_host_fd;
+    fd_cage_table[nap_child->cage_id][fd] = child_host_fd;
 
 
-    NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", parent_fd, nap_child->fd - 1);
+    NaClLog(1, "NaClGetDesc() copied parent fd [%d] to child fd [%d]\n", fd);
   }
   NaClXMutexUnlock(&nap_parent->mu);
 

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -117,7 +117,6 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     NaClXMutexUnlock(&nap_parent->children_mu);
   }
 
-  //NaClAppInitialDescriptorHookup(nap_child);
   NaClLog(1, "fork_num = %d, cage_id = %d\n", fork_num, nap_child->cage_id);
   if ((*mod_status = NaClAppLoadFileFromFilename(nap_child, nap_child->nacl_file)) != LOAD_OK) {
     NaClLog(1, "Error while loading \"%s\": %s\n", nap_child->nacl_file, NaClErrorString(*mod_status));
@@ -151,8 +150,8 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
 
     /* Retrive the host fd we had stored in the Cage Table for the parent */
     int parent_host_fd = fd_cage_table[nap_parent->cage_id][fd];
-    if (parent_host_fd == -1) {
-      fd_cage_table[nap_child->cage_id][fd] = -1;
+    if (parent_host_fd == NACL_BAD_FD) {
+      fd_cage_table[nap_child->cage_id][fd] = NACL_BAD_FD;
       continue;
     }
     /* Retrieve Parent NaCl Descriptor based on current child fd in the parent */

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -117,7 +117,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     NaClXMutexUnlock(&nap_parent->children_mu);
   }
 
-  NaClAppInitialDescriptorHookup(nap_child);
+  //NaClAppInitialDescriptorHookup(nap_child);
   NaClLog(1, "fork_num = %d, cage_id = %d\n", fork_num, nap_child->cage_id);
   if ((*mod_status = NaClAppLoadFileFromFilename(nap_child, nap_child->nacl_file)) != LOAD_OK) {
     NaClLog(1, "Error while loading \"%s\": %s\n", nap_child->nacl_file, NaClErrorString(*mod_status));
@@ -146,7 +146,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
   
   /* duplicate file descriptor table starting at child_fd = 3 (0-2 setup previously)*/
   NaClXMutexLock(&nap_parent->mu);
-  for (int parent_fd = nap_child->fd; parent_fd <= nap_parent->fd; parent_fd++) {
+  for (int parent_fd = 0; parent_fd <= FILE_DESC_MAX; parent_fd++) {
 
     /* Retrive the host fd we had stored in the Cage Table for the parent */
     int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -150,8 +150,8 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
 
     /* Retrive the host fd we had stored in the Cage Table for the parent */
     int parent_host_fd = fd_cage_table[nap_parent->cage_id][parent_fd];
-    if (parent_host_fd == 0) {
-      fd_cage_table[nap_child->cage_id][nap_child->fd++] = 0;
+    if (parent_host_fd == -1) {
+      fd_cage_table[nap_child->cage_id][nap_child->fd++] = -1;
       continue;
     }
     /* Retrieve Parent NaCl Descriptor based on current child fd in the parent */

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4343,7 +4343,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   NaClXMutexLock(&nap->mu); 
   NaClXMutexLock(&nap_child->mu); 
   NaClLog(2, "Copying fd table in SafePOSIX\n");
-  lind_fork(nap_child->cage_id, nap->cage_id);
+  lind_exec(nap_child->cage_id, nap->cage_id);
   NaClXMutexUnlock(&nap_child->mu);
   NaClXMutexUnlock(&nap->mu);
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -558,7 +558,7 @@ int32_t NaClSysDup2(struct NaClAppThread  *natp,
   new_hostfd = fd_cage_table[nap->cage_id][newfd];
 
 
-  if (!new_nd) {
+  if (new_hostfd < 0) {
     
     /* Scenario 1: Create and set vars for new hd */
     struct NaClHostDesc *new_hd;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -810,7 +810,7 @@ int32_t NaClSysClose(struct NaClAppThread *natp, int d) {
   }
 
   /* mark file descriptor d as invalid (stdin is not a valid file descriptor) */
-  fd_cage_table[nap->cage_id][d] = -1;
+  fd_cage_table[nap->cage_id][d] = NACL_BAD_FD;
 
   NaClFastMutexUnlock(&nap->desc_mu);
   return ret;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -1591,7 +1591,7 @@ int32_t NaClSysMmapIntern(struct NaClApp        *nap,
   } else {
     fd = fd_cage_table[nap->cage_id][d];
     if (fd < 0) {
-      retval = -NACL_ABI_EBADF;
+      map_result = -NACL_ABI_EBADF;
       goto cleanup;
     }
     ndp = NaClGetDesc(nap, fd);

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -59,6 +59,8 @@
 #include "native_client/src/trusted/simple_service/nacl_simple_rservice.h"
 #include "native_client/src/trusted/simple_service/nacl_simple_service.h"
 #include "native_client/src/trusted/threading/nacl_thread_interface.h"
+#include "native_client/src/trusted/service_runtime/include/sys/errno.h"
+
 
 double time_counter = 0.0;
 double time_start = 0.0;
@@ -1781,5 +1783,5 @@ int NextFd(int cage_id){
     if (fd_cage_table[cage_id][fd] == -1) return fd;
   }
 
-  return -1;
+  return -NACL_ABI_EBADF;
 }

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -837,6 +837,30 @@ void NaClAppInitialDescriptorHookup(struct NaClApp  *nap) {
   nap->resource_phase = NACL_RESOURCE_PHASE_START;
   NaClProcessRedirControl(nap);
   NaClLog(4, "... done.\n");
+
+
+  /* Set up cage-id's for initial descriptors */
+  for (int fd = 0; fd < 3; fd++) {
+
+    /* Retrieve NaCl Descriptor based on fd */
+    int host_fd = fd_cage_table[nap->cage_id][fd];
+
+    struct NaClDesc *nd;
+    nd = NaClGetDesc(nap, host_fd);
+    if (!nd) {
+      continue;
+    }
+
+    /* Translate from NaCl Desc to Host Desc */
+    struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) &nd->base;
+    struct NaClHostDesc *hd = self->hd;
+
+    hd->cageid = nap->cage_id;
+
+    /* We've got to put that  NaClDescriptor back in there... */
+    NaClSetDesc(nap, host_fd, nd);
+
+  }
 }
 
 void NaClCreateServiceSocket(struct NaClApp *nap) {

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1769,7 +1769,6 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
   for (int fd = 3; fd < FILE_DESC_MAX; fd++) fd_cage_table[cage_id][fd] = -1;
 
   /* set to the next unused (available for dup() etc.) file descriptor */
-  nap->fd = 3;
   nap->num_lib = 3;
   nap->num_children = 0;
   nap->cage_id = cage_id;

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1782,5 +1782,5 @@ int NextFd(int cage_id){
     if (fd_cage_table[cage_id][fd] == -1) return fd;
   }
 
-  return NACL_BAD_FD;
+  return -NACL_ABI_EBADF;
 }

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1772,3 +1772,14 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
   nap->num_children = 0;
   nap->cage_id = cage_id;
 }
+
+/* Find next available fd in cagetable */
+
+int NextFd(int cage_id){
+
+  for (int fd = 0; fd < FILE_DESC_MAX; fd ++) {
+    if (fd == -1) return fd;
+  }
+
+  return -1;
+}

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1782,5 +1782,5 @@ int NextFd(int cage_id){
     if (fd_cage_table[cage_id][fd] == -1) return fd;
   }
 
-  return -NACL_ABI_EBADF;
+  return NACL_BAD_FD;
 }

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1778,7 +1778,7 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
 int NextFd(int cage_id){
 
   for (int fd = 0; fd < FILE_DESC_MAX; fd ++) {
-    if (fd == -1) return fd;
+    if (fd_cage_table[cage_id][fd] == -1) return fd;
   }
 
   return -1;

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1762,6 +1762,10 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
   fd_cage_table[cage_id][0] = 0;
   fd_cage_table[cage_id][1] = 1;
   fd_cage_table[cage_id][2] = 2;
+
+  /* Initialize unused fd's to -1 */
+  for (int fd = 3; fd < FILE_DESC_MAX; fd++) fd_cage_table[cage_id][fd] = -1;
+
   /* set to the next unused (available for dup() etc.) file descriptor */
   nap->fd = 3;
   nap->num_lib = 3;

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -70,6 +70,8 @@ EXTERN_C_BEGIN
 
 #define NACL_DEFAULT_STACK_MAX  (16u << 20)  /* main thread stack */
 
+#define NACL_BAD_FD                     -1
+
 struct NaClAppThread;
 struct NaClDesc;  /* see native_client/src/trusted/desc/nacl_desc_base.h */
 struct NaClDynamicRegion;

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -927,6 +927,9 @@ void NaClCopyExecutionContext(struct NaClApp *nap_parent, struct NaClApp *nap_ch
 /* Set up the fd table for each cage */
 void InitializeCage(struct NaClApp *nap, int cage_id);
 
+/* Find the next usuable fd */
+int NextFd(int cage_id);
+
 static INLINE void NaClLogUserMemoryContent(struct NaClApp *nap, uintptr_t user_addr) {
   char *addr = (char *)NaClUserToSys(nap, user_addr);
   NaClLog(1, "[Memory] Memory addr:                   %p\n", (void *)addr);

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -149,8 +149,7 @@ struct NaClApp {
   char                      *nacl_file;
   char const *const         *clean_environ;
   volatile int              in_fork;
-  /* set to the next unused (available for dup() etc.) file descriptor */
-  int                       fd;
+
 
   /*
    * public, user settable prior to app start.

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -237,6 +237,10 @@ int NaClSelLdrMain(int argc, char **argv) {
 
   nacl_main_begin = clock();
 
+  /* Initialize cage early on to avoid Cage 0 */
+  InitializeCage(nap, 1);
+
+
   if (!DynArrayCtor(&nap->children, 16)) {
     NaClLog(1, "%s\n", "Failed to initialize children list");
   }
@@ -829,7 +833,6 @@ int NaClSelLdrMain(int argc, char **argv) {
   }
 
   NACL_TEST_INJECTION(BeforeMainThreadLaunches, ());
-  InitializeCage(nap, 1);
   NaClLog(1, "[NaCl Main][Cage 1] argv[3]: %s \n\n", (argv + optind)[3]);
   NaClLog(1, "[NaCl Main][Cage 1] argv[4]: %s \n\n", (argv + optind)[4]);
   NaClLog(1, "[NaCl Main][Cage 1] argv num: %d \n\n", argc - optind);


### PR DESCRIPTION
This PR:

1. Fixes the cagetable, and fixes std stream cage initialization
2. Fixes fd allocation to use a next available system
3. Adds RPC for exec
4. Fixes how dup2 checks for existing fds