### PR TITLE
Wait debug

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -103,7 +103,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
     }
     NaClLog(1, "[nap %d] incrementing num_children\n", nap_arr[i]->cage_id);
     
-    nap_arr[i]->num_children++];
+    nap_arr[i]->num_children++;
 
     if (nap_arr[i]->num_children > CHILD_NUM_MAX) {
       NaClLog(LOG_FATAL, "[nap %u] child_idx > %d\n", nap_arr[i]->cage_id, CHILD_NUM_MAX);
@@ -334,7 +334,6 @@ void NaClAppThreadTeardown(struct NaClAppThread *natp) {
   struct NaClApp  *nap_master = NULL;
   struct NaClApp  *nap_parent = nap->parent;
   size_t          thread_idx;
-  int             list_idx;
 
   if (master_ctx) {
     nap_master = ((struct NaClAppThread *)master_ctx)->nap;
@@ -368,8 +367,9 @@ void NaClAppThreadTeardown(struct NaClAppThread *natp) {
         if (!DynArraySet(&nap_arr[i]->children, nap->cage_id, NULL)) {
           NaClLog(1, "[NaClAppThreadTeardown][parent %d] did not find cage to remove: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
         }
-        else NaClLog(1, "[NaClAppThreadTeardown][parent %d] removed cage: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
-
+        else {
+          NaClLog(1, "[NaClAppThreadTeardown][parent %d] removed cage: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
+        }
       }
       NaClXCondVarBroadcast(&nap_arr[i]->children_cv);
     }

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -362,15 +362,15 @@ void NaClAppThreadTeardown(struct NaClAppThread *natp) {
         continue;
       }
    
-        nap_arr[i]->num_children--;
-        NaClLog(1, "[parent %d] new child count: %d\n", nap_arr[i]->cage_id, nap_arr[i]->num_children);
-        if (!DynArraySet(&nap_arr[i]->children, nap->cage_id, NULL)) {
-          NaClLog(1, "[NaClAppThreadTeardown][parent %d] did not find cage to remove: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
-        }
-        else {
-          NaClLog(1, "[NaClAppThreadTeardown][parent %d] removed cage: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
-        }
+      nap_arr[i]->num_children--;
+      NaClLog(1, "[parent %d] new child count: %d\n", nap_arr[i]->cage_id, nap_arr[i]->num_children);
+      if (!DynArraySet(&nap_arr[i]->children, nap->cage_id, NULL)) {
+        NaClLog(1, "[NaClAppThreadTeardown][parent %d] did not find cage to remove: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
       }
+      else {
+        NaClLog(1, "[NaClAppThreadTeardown][parent %d] removed cage: cage_id = %d\n", nap_arr[i]->cage_id, nap->cage_id);
+      }
+      
       NaClXCondVarBroadcast(&nap_arr[i]->children_cv);
     }
     /* don't unlock master twice */

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -102,7 +102,14 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap) {
       continue;
     }
     NaClLog(1, "[nap %d] incrementing num_children\n", nap_arr[i]->cage_id);
+    
+    printf("%d number of children \n", nap_arr[i]->num_children);
+
     nap_arr[i]->children_ids[nap_arr[i]->num_children++] = nap_child->cage_id;
+
+
+    printf("%d number of children \n", nap_arr[i]->num_children);
+
     if (nap_arr[i]->num_children > CHILD_NUM_MAX) {
       NaClLog(LOG_FATAL, "[nap %u] child_idx > %d\n", nap_arr[i]->cage_id, CHILD_NUM_MAX);
     }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4413,7 +4413,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   }
 
   /*
-   * explicit child pid given
+   * WAITPID: explicit child pid given
    */
   if (pid > 0 && pid <= pid_max) {
     int cage_id = pid;
@@ -4438,15 +4438,14 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   }
 
   /*
-   * TODO: implement pid == WAIT_ANY_PG (0) and pid == WAIT_ANY (-1) behavior
-   *
-   * -jp
+   * WAIT or WAITPID(-1)
+   * TODO: implement pid == WAIT_ANY_PG (0), we currently don't deal with process groups
    */
   if (pid <= 0) {
     while(1){
 
       /* Starting at 1 here, we shouldn't be waiting for the master cage, 0 */
-      for (int cage_id = 1; cage_id < fork_num; cage_id++) {
+      for (int cage_id = 0; cage_id < fork_num; cage_id++) {
 
         NaClXMutexLock(&nap->children_mu);
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4433,6 +4433,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     }
     NaClXCondVarBroadcast(&nap->children_cv);
     NaClXMutexUnlock(&nap->children_mu);
+    ret = pid;
     goto out;
   }
 
@@ -4483,7 +4484,7 @@ out:
   if (nap_child && stat_loc_ptr) {
     *stat_loc_ptr = nap_child->exit_status;
   }
-  NaClLog(1, "[NaClSysWaitpid] pid = %d \n", cage_id);
+  NaClLog(1, "[NaClSysWaitpid] pid = %d \n", pid);
   NaClLog(1, "[NaClSysWaitpid] status = %d \n", stat_loc_ptr ? *stat_loc_ptr : 0);
   NaClLog(1, "[NaClSysWaitpid] options = %d \n", options);
   NaClLog(1, "[NaClSysWaitpid] ret = %d \n", ret);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4444,7 +4444,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   if (pid <= 0) {
     while(1){
 
-      /* Starting at 1 here, we shouldn't be waiting for the master cage, 0 */
+      /* Cycle through possible cages up to the fork number (max amount of created cages) */
       for (int cage_id = 0; cage_id < fork_num; cage_id++) {
 
         NaClXMutexLock(&nap->children_mu);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4390,14 +4390,14 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
                        int pid,
                        uint32_t *stat_loc,
                        int options) {
-  volatile int cage_id = pid;
+
   /* seconds between thread switching */
   NACL_TIMESPEC_T const timeout = {1, 0};
   struct NaClApp *nap = natp->nap;
   struct NaClApp *nap_child = 0;
   uintptr_t sysaddr = NaClUserToSysAddrRange(nap, (uintptr_t)stat_loc, 4);
   int *stat_loc_ptr = sysaddr == kNaClBadAddress ? NULL : (int *)sysaddr;
-  int pid_max = 0;
+  int pid_max = fork_num;
   int ret = 0;
 
   NaClLog(1, "%s\n", "[NaClSysWaitpid] entered waitpid!");
@@ -4406,9 +4406,8 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   if (stat_loc_ptr) {
     *stat_loc_ptr = 0;
   }
-  for (int i = 0; i < nap->num_children; i++)
-    pid_max = pid_max < nap->children_ids[i] ? nap->children_ids[i] : pid_max;
-  if (!nap->num_children || cage_id > pid_max) {
+
+  if (!nap->num_children || pid > pid_max) {
     ret = -NACL_ABI_ECHILD;
     goto out;
   }
@@ -4416,7 +4415,8 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   /*
    * explicit child pid given
    */
-  if (cage_id > 0 && cage_id <= pid_max) {
+  if (pid > 0 && pid <= pid_max) {
+    int cage_id = pid;
     /* make sure children exists */
     NaClXMutexLock(&nap->children_mu);
     nap_child = DynArrayGet(&nap->children, cage_id);
@@ -4441,36 +4441,42 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
    *
    * -jp
    */
-  if (cage_id <= 0) {
-    volatile int cur_idx = 0;
-    for (;;) {
-      /* make sure children exist */
-      NaClXMutexLock(&nap->children_mu);
-      if (!nap->num_children) {
-        ret = -NACL_ABI_ECHILD;
-        NaClXCondVarBroadcast(&nap->children_cv);
-        NaClXMutexUnlock(&nap->children_mu);
-        goto out;
-      }
-      /* wait for next child to exit */
-      cage_id = nap->children_ids[cur_idx];
-      if (cage_id && (nap_child = DynArrayGet(&nap->children, cage_id))) {
-        NaClLog(1, "Thread children count: %d\n", nap->num_children);
-        NaClXCondVarTimedWaitRelative(&nap->children_cv, &nap->children_mu, &timeout);
-        /* exit if selected child has finished */
-        if (!(nap_child = DynArrayGet(&nap->children, cage_id)) || !nap_child->running) {
-          ret = cage_id;
+  if (pid <= 0) {
+    while(1){
+
+      /* Starting at 1 here, we shouldn't be waiting for the master cage, 0 */
+      for (int cage_id = 1; cage_id < fork_num; cage_id++) {
+
+        NaClXMutexLock(&nap->children_mu);
+
+        /* make sure children exist, if not send ABI_ECHILD */
+        if (!nap->num_children) {
+          ret = -NACL_ABI_ECHILD;
           NaClXCondVarBroadcast(&nap->children_cv);
           NaClXMutexUnlock(&nap->children_mu);
           goto out;
         }
+        /* wait for next child to exit */
+        nap_child = DynArrayGet(&nap->children, cage_id);
+        if (nap_child) {
+          NaClLog(1, "Thread children count: %d\n", nap->num_children);
+          NaClXCondVarTimedWaitRelative(&nap->children_cv, &nap->children_mu, &timeout);
+          /* exit if selected child has finished */
+          if (!(nap_child = DynArrayGet(&nap->children, cage_id)) || !nap_child->running) {
+            ret = cage_id;
+            NaClXCondVarBroadcast(&nap->children_cv);
+            NaClXMutexUnlock(&nap->children_mu);
+            goto out;
+          }
+        }
+    
+        NaClXCondVarBroadcast(&nap->children_cv);
+
+        NaClXMutexUnlock(&nap->children_mu);
       }
-      if (++cur_idx > CHILD_NUM_MAX) {
-        cur_idx = 0;
-      }
-      NaClXCondVarBroadcast(&nap->children_cv);
-      NaClXMutexUnlock(&nap->children_mu);
+      
     }
+    
   }
 
 out:

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -724,10 +724,9 @@ void NaClAddHostDescriptor(struct NaClApp *nap,
   }
   NaClSetDesc(nap, nacl_desc, (struct NaClDesc *)dp);
   if (host_os_desc >= FILE_DESC_MAX) {
-    NaClLog(LOG_FATAL, "NaClAddHostDescriptor: fd %d is too large for fd_maps\n", host_os_desc);
+    NaClLog(LOG_FATAL, "NaClAddHostDescriptor: fd %d is too large\n", host_os_desc);
     return;
   }
-  nap->fd_maps[host_os_desc] = (struct NaClDesc *)dp;
 }
 
 void NaClAddImcHandle(struct NaClApp  *nap,
@@ -1769,7 +1768,6 @@ void InitializeCage(struct NaClApp *nap, int cage_id) {
   for (int fd = 3; fd < FILE_DESC_MAX; fd++) fd_cage_table[cage_id][fd] = -1;
 
   /* set to the next unused (available for dup() etc.) file descriptor */
-  nap->num_lib = 3;
   nap->num_children = 0;
   nap->cage_id = cage_id;
 }

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -136,11 +136,9 @@ struct NaClApp {
   struct NaClApp            *parent;
   struct NaClApp            *master;
   /* mappings of `int fd` numbers to `NaClDesc *` */
-  struct NaClDesc           *fd_maps[FILE_DESC_MAX];
   volatile sig_atomic_t     children_ids[CHILD_NUM_MAX];
   volatile sig_atomic_t     num_children;
   volatile sig_atomic_t     cage_id;
-  volatile sig_atomic_t     num_lib;
   volatile sig_atomic_t     parent_id;
   enum NaClThreadLaunchType tl_type;
 

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -135,8 +135,7 @@ struct NaClApp {
   struct DynArray           children;
   struct NaClApp            *parent;
   struct NaClApp            *master;
-  /* mappings of `int fd` numbers to `NaClDesc *` */
-  volatile sig_atomic_t     children_ids[CHILD_NUM_MAX];
+
   volatile sig_atomic_t     num_children;
   volatile sig_atomic_t     cage_id;
   volatile sig_atomic_t     parent_id;


### PR DESCRIPTION
I somehow fast tracked this Pull Request accidentally, so doing it again for a code review.

Here I fixed a problem with wait where a children_id table was being used in a linear fashion, which caused a bug due to children not exiting in any pre-known order. The fix here gets rid of that table and just uses the dynamic array of ptrs to child naps. It also gets rid of some other unused nap variables.