### PR TITLE
Remove extra syscalls from NaCl

### DIFF
--- a/src/shared/platform/posix/nacl_host_desc.c
+++ b/src/shared/platform/posix/nacl_host_desc.c
@@ -320,27 +320,7 @@ int NaClHostDescOpen(struct NaClHostDesc  *d,
     NaClLog(2, "NaClHostDescOpen: open returned -1, errno %d\n", errno);
     return -NaClXlateErrno(errno);
   }
-  if (-1 ==
-#if NACL_LINUX
-      lind_fxstat(host_desc, 1, &stbuf, d->cageid)
-#else
-      lind_fxstat(host_desc, 1, &stbuf, d->cageid)
-#endif
-      ) {
-    NaClLog(LOG_ERROR,
-            "NaClHostDescOpen: fstat failed?!?  errno %d\n", errno);
-    (void) lind_close(host_desc, d->cageid);
-    return -NaClXlateErrno(errno);
-  }
-#if 0
-  if (!S_ISREG(stbuf.st_mode)) {
-    NaClLog(LOG_INFO,
-            "NaClHostDescOpen: file type 0x%x, not regular\n", stbuf.st_mode);
-    (void) close(host_desc);
-    /* cannot access anything other than a real file */
-    return -NACL_ABI_EPERM;
-  }
-#endif
+ 
   return NaClHostDescCtor(d, host_desc, flags);
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -839,11 +839,10 @@ int32_t NaClSysGetdents(struct NaClAppThread *natp,
    */
   NaClXMutexLock(&nap->mu);
 
-  
   getdents_ret = lind_getdents(lind_fd,
-                            (void *) sysaddr,
-                            count,
-                            nap->cage_id);
+                              count,
+                              (void *) sysaddr,
+                              nap->cage_id);
   NaClXMutexUnlock(&nap->mu);
   /* drop addr space lock */
   if ((getdents_ret < INT32_MIN && !NaClSSizeIsNegErrno(&getdents_ret))

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -829,7 +829,7 @@ int32_t NaClSysGetdents(struct NaClAppThread *natp,
   }
 
 
-  struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) vself;
+  struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) ndp;
   int lind_fd = self->hd->d;
 
   /*
@@ -2070,7 +2070,7 @@ int32_t NaClSysMmapIntern(struct NaClApp        *nap,
                               flags,
                               ndp,
                               offset,
-                              file_size);
+                              length);
   }
 
   map_result = usraddr;


### PR DESCRIPTION
Removed fstat in open and mmap
Changed open to create NaClDesc for directories instead of NaClDir, and getdents to go directly to a safeposix call to avoid using NaCl dirs. This allows the removal of stat in open.