### PR TITLE
Moved shutdown() call.

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -571,10 +571,10 @@ int lind_getsockopt (int sockfd, int level, int optname, socklen_t optlen, void 
     LIND_API_PART3;
 }
 
-int lind_shutdown (int sockfd, int how)
+int lind_shutdown (int sockfd, int how, int cageid)
 {
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[ii])", LIND_safe_net_shutdown, sockfd, how);
+    callArgs = Py_BuildValue("(i[iii])", LIND_safe_net_shutdown, sockfd, how, cageid);
     LIND_API_PART2;
     LIND_API_PART3;
 }

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -69,7 +69,7 @@
 #define LIND_safe_net_getsockname       42
 #define LIND_safe_net_getsockopt        43
 #define LIND_safe_net_setsockopt        44
-#define LIND_safe_net_shutdown          45 //unchanged, already in location
+#define LIND_safe_net_shutdown          45
 #define LIND_safe_net_select            46
 #define LIND_safe_net_getifaddrs        47
 #define LIND_safe_net_poll              48

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -69,7 +69,7 @@
 #define LIND_safe_net_getsockname       42
 #define LIND_safe_net_getsockopt        43
 #define LIND_safe_net_setsockopt        44
-#define LIND_safe_net_shutdown          45
+#define LIND_safe_net_shutdown          45 //unchanged, already in location
 #define LIND_safe_net_select            46
 #define LIND_safe_net_getifaddrs        47
 #define LIND_safe_net_poll              48
@@ -145,7 +145,7 @@ int lind_accept (int sockfd, socklen_t addrlen);
 int lind_getpeername (int sockfd, socklen_t addrlen_in, __SOCKADDR_ARG addr, socklen_t * addrlen_out);
 int lind_setsockopt (int sockfd, int level, int optname, socklen_t optlen, const void *optval);
 int lind_getsockopt (int sockfd, int level, int optname, socklen_t optlen, void *optval);
-int lind_shutdown (int sockfd, int how);
+int lind_shutdown (int sockfd, int how, int cageid);
 int lind_select (int nfds, fd_set * readfds, fd_set * writefds, fd_set * exceptfds, struct timeval *timeout, struct select_results *result);
 int lind_getifaddrs (int ifaddrs_buf_siz, void *ifaddrs);
 int lind_recvfrom (int sockfd, size_t len, int flags, socklen_t addrlen, socklen_t * addrlen_out, void *buf, struct sockaddr *src_addr, int cageid);

--- a/src/trusted/service_runtime/include/bits/nacl_syscalls.h
+++ b/src/trusted/service_runtime/include/bits/nacl_syscalls.h
@@ -60,6 +60,7 @@
 #define NACL_sys_nanosleep              42
 #define NACL_sys_clock_getres           43
 #define NACL_sys_clock_gettime          44
+#define NACL_sys_shutdown               45
 
 #define NACL_sys_getcwd                 48
 

--- a/src/trusted/service_runtime/lind_syscalls.c
+++ b/src/trusted/service_runtime/lind_syscalls.c
@@ -745,7 +745,7 @@ StubType stubs[] = {
         {LindCommonPreprocess, 0, 0}, /* 42 LIND_safe_net_getsockname */
         {LindCommonPreprocess, 0, 0}, /* 43 LIND_safe_net_getsockopt */
         {LindCommonPreprocess, 0, 0}, /* 44 LIND_safe_net_setsockopt */
-        {0},
+        {0}, /* 45 */
         {LindSelectPreprocess, LindSelectPostprocess, LindSelectCleanup}, /* 46 LIND_safe_net_select */
         {0}, /* 47 */
         {LindPollPreprocess, LindPollPostprocess, LindPollCleanup}, /* 48 LIND_safe_net_poll */

--- a/src/trusted/service_runtime/lind_syscalls.c
+++ b/src/trusted/service_runtime/lind_syscalls.c
@@ -745,7 +745,7 @@ StubType stubs[] = {
         {LindCommonPreprocess, 0, 0}, /* 42 LIND_safe_net_getsockname */
         {LindCommonPreprocess, 0, 0}, /* 43 LIND_safe_net_getsockopt */
         {LindCommonPreprocess, 0, 0}, /* 44 LIND_safe_net_setsockopt */
-        {LindCommonPreprocess, 0, 0}, /* 45 LIND_safe_net_shutdown */
+        {0},
         {LindSelectPreprocess, LindSelectPostprocess, LindSelectCleanup}, /* 46 LIND_safe_net_select */
         {0}, /* 47 */
         {LindPollPreprocess, LindPollPostprocess, LindPollCleanup}, /* 48 LIND_safe_net_poll */

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4567,7 +4567,7 @@ int32_t NaClSysGethostname(struct NaClAppThread *natp, char *name, size_t len) {
           "%d)\n",
           nap->cage_id, (uintptr_t) natp, (uintptr_t) name, len);
   
-  /*Convert user addres to system adres*/
+  /*Convert user address to system address*/
   sysaddr = NaClUserToSysAddrRange(nap, (uintptr_t) name, len);
   if (kNaClBadAddress == sysaddr) {
     ret = -NACL_ABI_EFAULT;
@@ -4725,5 +4725,18 @@ int32_t NaClSysRecvfrom(struct NaClAppThread *natp, int sockfd, size_t len, int 
 
   ret = lind_recvfrom(sockfd, len, flags, addrlen, addrlen_out, sysbufaddr, src_addr, nap->cage_id);
   NaClLog(2, "NaClSysRecvfrom: returning %d\n", ret);
+  return ret;
+}
+
+int32_t NaClSysShutdown(struct NaClAppThread *natp, int sockfd, int how)
+{
+  int32_t ret;
+  struct NaClApp *nap = natp->nap;
+
+  NaClLog(2, "Cage %d Entered NaClSysShutdown(0x%08"NACL_PRIxPTR", %d, %d)\n",
+          nap->cage_id, (uintptr_t) natp, sockfd, how);
+
+  ret = lind_shutdown(sockfd, how, nap->cageid);
+  NaClLog(2, "NaClSysShutdown returning %d\n", ret);
   return ret;
 }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4736,6 +4736,11 @@ int32_t NaClSysShutdown(struct NaClAppThread *natp, int sockfd, int how)
   NaClLog(2, "Cage %d Entered NaClSysShutdown(0x%08"NACL_PRIxPTR", %d, %d)\n",
           nap->cage_id, (uintptr_t) natp, sockfd, how);
 
+  if((sockfd = descnum2Lindfd(nap, sockfd)) < 0) {
+    NaClLog(2, "NaClSysShutdown was passed an unrecognized file descriptor, returning %d\n", sockfd);
+    return sockfd;
+  }
+  
   ret = lind_shutdown(sockfd, how, nap->cageid);
   NaClLog(2, "NaClSysShutdown returning %d\n", ret);
   return ret;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4741,7 +4741,7 @@ int32_t NaClSysShutdown(struct NaClAppThread *natp, int sockfd, int how)
     return sockfd;
   }
   
-  ret = lind_shutdown(sockfd, how, nap->cageid);
+  ret = lind_shutdown(sockfd, how, nap->cage_id);
   NaClLog(2, "NaClSysShutdown returning %d\n", ret);
   return ret;
 }

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -345,6 +345,8 @@ int32_t NaClSysRecv(struct NaClAppThread *natp, int sockfd, size_t len, int flag
 int32_t NaClSysRecvfrom(struct NaClAppThread *natp, int sockfd, size_t len, int flags,
                            socklen_t addrlen, socklen_t * addrlen_out, void *buf, struct sockaddr *src_addr);
 
+int32_t NaClSysShutdown(struct NaClAppThread *natp, int sockfd, int how);
+
 EXTERN_C_END
 
 #endif  /* NATIVE_CLIENT_SERVICE_RUNTIME_NACL_SYSCALL_COMMON_H__ */

--- a/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
+++ b/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
@@ -272,7 +272,8 @@ SYSCALL_LIST = [
      ['int sockfd', 'const void *buf', 'size_t len', 'int flags', 'const struct sockaddr *dest_addr', 'socklen_t addrlen']),
     ('NACL_sys_recv', 'NaClSysRecv', ['int sockfd', 'size_t len', 'int flags', 'void *buf']),
     ('NACL_sys_recvfrom', 'NaClSysRecvfrom',
-     ['int sockfd', 'size_t len', 'int flags', 'socklen_t addrlen', 'socklen_t * addrlen_out', 'void *buf', 'struct sockaddr *src_addr'])
+     ['int sockfd', 'size_t len', 'int flags', 'socklen_t addrlen', 'socklen_t * addrlen_out', 'void *buf', 'struct sockaddr *src_addr']),
+     ('NACL_sys_shutdown', 'NaClSysShutdown', ['int sockfd', 'int how'])
     ]
 
 


### PR DESCRIPTION
Moved shutdown() call, should be working correctly.
To test it, add these two lines to serverclient.c after line 73 in unified_syscalls.

```
    shutdown(server_fd,SHUT_RDWR);
    printf("Shutdownsent\n");
```