### PR TITLE
Moved flock call.

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -696,10 +696,10 @@ int lind_getegid (gid_t * buf)
     LIND_API_PART3;
 }
 
-int lind_flock (int fd, int operation)
+int lind_flock (int fd, int operation, int cageid)
 {
     LIND_API_PART1;
-    callArgs = Py_BuildValue("(i[ii])", LIND_safe_fs_flock, fd, operation);
+    callArgs = Py_BuildValue("(i[iii])", LIND_safe_fs_flock, fd, operation, cageid);
     LIND_API_PART2;
     LIND_API_PART3;
 }

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -155,7 +155,7 @@ int lind_getuid (uid_t * buf);
 int lind_geteuid (uid_t * buf);
 int lind_getgid (gid_t * buf);
 int lind_getegid (gid_t * buf);
-int lind_flock (int fd, int operation);
+int lind_flock (int fd, int operation, int cageid);
 int lind_pipe(int* pipefds, int cageid);
 int lind_pipe2(int* pipefds, int flags, int cageid);  /* unimplemented */
 int lind_fork(int newcageid, int cageid);

--- a/src/trusted/service_runtime/include/bits/nacl_syscalls.h
+++ b/src/trusted/service_runtime/include/bits/nacl_syscalls.h
@@ -64,6 +64,7 @@
 
 #define NACL_sys_getcwd                 48
 
+#define NACL_sys_flock                  54
 /* 50-58 previously used for multimedia syscalls */
 
 #define NACL_sys_imc_makeboundsock      60

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4745,3 +4745,16 @@ int32_t NaClSysShutdown(struct NaClAppThread *natp, int sockfd, int how)
   NaClLog(2, "NaClSysShutdown returning %d\n", ret);
   return ret;
 }
+
+int32_t NaClSysFlock(struct NaClAppThread *natp, int fd, int operation)
+{
+  int32_t ret;
+  struct NaClApp *nap = natp->nap;
+
+  NaClLog(2, "Cage %d Entered NaClSysFlock(0x%08"NACL_PRIxPTR", %d, %d)\n",
+          nap->cage_id, (uintptr_t) natp, fd, operation);
+  
+  ret = lind_flock(fd, operation, nap->cage_id);
+  NaClLog(2, "NaClSysFlock returning %d\n", ret);
+  return ret;
+}

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -346,6 +346,7 @@ int32_t NaClSysRecvfrom(struct NaClAppThread *natp, int sockfd, size_t len, int 
                            socklen_t addrlen, socklen_t * addrlen_out, void *buf, struct sockaddr *src_addr);
 
 int32_t NaClSysShutdown(struct NaClAppThread *natp, int sockfd, int how);
+int32_t NaClSysFlock(struct NaClAppThread *natp, int fd, int operation);
 
 EXTERN_C_END
 

--- a/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
+++ b/src/trusted/service_runtime/nacl_syscall_handlers_gen.py
@@ -273,7 +273,8 @@ SYSCALL_LIST = [
     ('NACL_sys_recv', 'NaClSysRecv', ['int sockfd', 'size_t len', 'int flags', 'void *buf']),
     ('NACL_sys_recvfrom', 'NaClSysRecvfrom',
      ['int sockfd', 'size_t len', 'int flags', 'socklen_t addrlen', 'socklen_t * addrlen_out', 'void *buf', 'struct sockaddr *src_addr']),
-     ('NACL_sys_shutdown', 'NaClSysShutdown', ['int sockfd', 'int how'])
+     ('NACL_sys_shutdown', 'NaClSysShutdown', ['int sockfd', 'int how']),
+     ('NACL_sys_flock', 'NaClSysFlock', ['int fd', 'int operation'])
     ]
 
 


### PR DESCRIPTION
```
[14604,1233749760:10:58:14.396641] Entering syscall 54: return address 0x68a50118e9e0
[14604,1233749760:10:58:14.396645] Cage 1 Entered NaClSysFlock(0x563b8f402f40, 3, 8)
[14604,1233749760:10:58:14.396655] Entered ParseResponse
[14604,1233749760:10:58:14.396659] ParseResponse isError=0, code=0, len=0
[14604,1233749760:10:58:14.396662] NaClSysFlock returning 0
[14604,1233749760:10:58:14.396664] Returning from syscall 54: return value 0 (0x0)
```