### PR TITLE
Dispatcher Errno Fix

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -28,7 +28,12 @@
     arg6.dispatch_ulong = 0//no semicolon here to force macro caller to place one for neatness
 
 #define DISPATCH_SYSCALL_0_inner(callnum) \
-    return dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6)//no semicolon here to force macro caller to place one for neatness
+    int ret = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6);
+    if (ret < 0) {
+        errno = -ret;
+        ret = -1;
+    }  
+    return ret//no semicolon here to force macro caller to place one for neatness
 #define DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val) \
     arg1.dispatch_ ## arg1type = arg1val; \
     DISPATCH_SYSCALL_0_inner(callnum)

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -33,10 +33,10 @@
 #define DISPATCH_SYSCALL_0_inner(callnum, errhandler) \
     int retval = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
     if (errhandler) { \
-        errno = -ret; \
-        ret = -1; \
+        errno = -retval; \
+        retval = -1; \
     }  \
-    return ret//no semicolon here to force macro caller to place one for neatness
+    return retval //no semicolon here to force macro caller to place one for neatness
 #define DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val, errhandler) \
     arg1.dispatch_ ## arg1type = arg1val; \
     DISPATCH_SYSCALL_0_inner(callnum, errhandler)

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -27,59 +27,62 @@
     arg5.dispatch_ulong = 0; \
     arg6.dispatch_ulong = 0//no semicolon here to force macro caller to place one for neatness
 
-#define DISPATCH_SYSCALL_0_inner(callnum) \
+#define GENERIC_ERROR_HANDLER   (ret < 0)
+#define MMAP_ERROR_HANDLER      ((unsigned) retval > (0xffffffffu - 256))
+
+#define DISPATCH_SYSCALL_0_inner(callnum, errhandler) \
     int ret = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
-    if (ret < 0) { \
+    if (errhandler) { \
         errno = -ret; \
         ret = -1; \
     }  \
     return ret//no semicolon here to force macro caller to place one for neatness
-#define DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val) \
+#define DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val, errhandler) \
     arg1.dispatch_ ## arg1type = arg1val; \
-    DISPATCH_SYSCALL_0_inner(callnum)
-#define DISPATCH_SYSCALL_2_inner(callnum, arg1type, arg1val, arg2type, arg2val) \
+    DISPATCH_SYSCALL_0_inner(callnum, errhandler)
+#define DISPATCH_SYSCALL_2_inner(callnum, arg1type, arg1val, arg2type, arg2val, errhandler) \
     arg2.dispatch_ ## arg2type = arg2val; \
-    DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val)
-#define DISPATCH_SYSCALL_3_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val) \
+    DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val, errhandler)
+#define DISPATCH_SYSCALL_3_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, errhandler) \
     arg3.dispatch_ ## arg3type = arg3val; \
-    DISPATCH_SYSCALL_2_inner(callnum, arg1type, arg1val, arg2type, arg2val)
+    DISPATCH_SYSCALL_2_inner(callnum, arg1type, arg1val, arg2type, arg2val, errhandler)
 #define DISPATCH_SYSCALL_4_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, \
-                                 arg4type, arg4val) \
+                                 arg4type, arg4val, errhandler) \
     arg4.dispatch_ ## arg4type = arg4val; \
-    DISPATCH_SYSCALL_3_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val)
+    DISPATCH_SYSCALL_3_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, errhandler)
 #define DISPATCH_SYSCALL_5_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, \
-                                 arg4type, arg4val, arg5type, arg5val) \
+                                 arg4type, arg4val, arg5type, arg5val, errhandler) \
     arg5.dispatch_ ## arg5type = arg5val; \
-    DISPATCH_SYSCALL_4_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val)
+    DISPATCH_SYSCALL_4_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, errhandler)
 #define DISPATCH_SYSCALL_6_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, \
-                                 arg4type, arg4val, arg5type, arg5val, arg6type, arg6val) \
+                                 arg4type, arg4val, arg5type, arg5val, arg6type, arg6val, errhandler) \
     arg6.dispatch_ ## arg6type = arg6val; \
-    DISPATCH_SYSCALL_5_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, arg5type, arg5val)
+    DISPATCH_SYSCALL_5_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, arg5type, arg5val, errhandler)
 
 
 #define DISPATCH_SYSCALL_6(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, \
                            arg4type, arg4val, arg5type, arg5val, arg6type, arg6val) \
     BLANKARGS; \
     DISPATCH_SYSCALL_6_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, \
-                             arg4type, arg4val, arg5type, arg5val, arg6type, arg6val)
+                             arg4type, arg4val, arg5type, arg5val, arg6type, arg6val, GENERIC_ERROR_HANDLER)
 #define DISPATCH_SYSCALL_5(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, arg5type, arg5val) \
     BLANKARGS; \
-    DISPATCH_SYSCALL_5_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, arg5type, arg5val)
+    DISPATCH_SYSCALL_5_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, arg5type, arg5val, GENERIC_ERROR_HANDLER)
 #define DISPATCH_SYSCALL_4(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val) \
     BLANKARGS; \
-    DISPATCH_SYSCALL_4_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val)
+    DISPATCH_SYSCALL_4_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, arg4type, arg4val, GENERIC_ERROR_HANDLER)
 #define DISPATCH_SYSCALL_3(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val) \
     BLANKARGS; \
-    DISPATCH_SYSCALL_3_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val)
+    DISPATCH_SYSCALL_3_inner(callnum, arg1type, arg1val, arg2type, arg2val, arg3type, arg3val, GENERIC_ERROR_HANDLER)
 #define DISPATCH_SYSCALL_2(callnum, arg1type, arg1val, arg2type, arg2val) \
     BLANKARGS; \
-    DISPATCH_SYSCALL_2_inner(callnum, arg1type, arg1val, arg2type, arg2val)
+    DISPATCH_SYSCALL_2_inner(callnum, arg1type, arg1val, arg2type, arg2val, GENERIC_ERROR_HANDLER)
 #define DISPATCH_SYSCALL_1(callnum, arg1type, arg1val) \
     BLANKARGS; \
-    DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val)
+    DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val, GENERIC_ERROR_HANDLER)
 #define DISPATCH_SYSCALL_0(callnum) \
     BLANKARGS; \
-    DISPATCH_SYSCALL_0_inner(callnum)
+    DISPATCH_SYSCALL_0_inner(callnum, GENERIC_ERROR_HANDLER)
 
 
 int lind_pread(int fd, void *buf, size_t count, off_t offset, int cageid) {
@@ -286,7 +289,7 @@ int lind_fork(int newcageid, int cageid) {
 }
 
 int lind_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset, int cageid) {
-    DISPATCH_SYSCALL_6(LIND_safe_fs_mmap, cbuf, addr, size_t, length, int, prot, int, flags, int, fd, off_t, offset);
+    DISPATCH_SYSCALL_6_inner(LIND_safe_fs_mmap, cbuf, addr, size_t, length, int, prot, int, flags, int, fd, off_t, offset, MMAP_ERROR_HANDLER);
 }
 
 int lind_munmap(void *addr, size_t length, int cageid) {

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -31,7 +31,8 @@
 #define MMAP_ERROR_HANDLER      ((unsigned) retval > (0xffffffffu - 256))
 
 #define DISPATCH_SYSCALL_0_inner(callnum, errhandler) \
-    int retval = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
+    int retval; \
+    retval = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
     if (errhandler) { \
         errno = -retval; \
         retval = -1; \

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -28,11 +28,11 @@
     arg6.dispatch_ulong = 0//no semicolon here to force macro caller to place one for neatness
 
 #define DISPATCH_SYSCALL_0_inner(callnum) \
-    int ret = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6);
-    if (ret < 0) {
-        errno = -ret;
-        ret = -1;
-    }  
+    int ret = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
+    if (ret < 0) { \
+        errno = -ret; \
+        ret = -1; \
+    }  \
     return ret//no semicolon here to force macro caller to place one for neatness
 #define DISPATCH_SYSCALL_1_inner(callnum, arg1type, arg1val) \
     arg1.dispatch_ ## arg1type = arg1val; \

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -27,11 +27,11 @@
     arg5.dispatch_ulong = 0; \
     arg6.dispatch_ulong = 0//no semicolon here to force macro caller to place one for neatness
 
-#define GENERIC_ERROR_HANDLER   (ret < 0)
+#define GENERIC_ERROR_HANDLER   (retval < 0)
 #define MMAP_ERROR_HANDLER      ((unsigned) retval > (0xffffffffu - 256))
 
 #define DISPATCH_SYSCALL_0_inner(callnum, errhandler) \
-    int ret = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
+    int retval = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
     if (errhandler) { \
         errno = -ret; \
         ret = -1; \

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -289,6 +289,7 @@ int lind_fork(int newcageid, int cageid) {
 }
 
 int lind_mmap(void *addr, size_t length, int prot, int flags, int fd, off_t offset, int cageid) {
+    BLANKARGS;
     DISPATCH_SYSCALL_6_inner(LIND_safe_fs_mmap, cbuf, addr, size_t, length, int, prot, int, flags, int, fd, off_t, offset, MMAP_ERROR_HANDLER);
 }
 

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -19,6 +19,7 @@
 #include "native_client/src/trusted/service_runtime/include/bits/nacl_syscalls.h"
 
 #define BLANKARGS \
+    int retval; \
     union RustArg arg1, arg2, arg3, arg4, arg5, arg6; \
     arg1.dispatch_ulong = 0; \
     arg2.dispatch_ulong = 0; \
@@ -31,7 +32,6 @@
 #define MMAP_ERROR_HANDLER      ((unsigned) retval > (0xffffffffu - 256))
 
 #define DISPATCH_SYSCALL_0_inner(callnum, errhandler) \
-    int retval; \
     retval = dispatcher(cageid, callnum, arg1, arg2, arg3, arg4, arg5, arg6); \
     if (errhandler) { \
         errno = -retval; \


### PR DESCRIPTION
This changes the dispatcher macros to:

1. Handle errnos correctly
2. Use different errno handlers for syscalls such as mmap which return addresses.