### PR TITLE
Break_addr fix

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -19,7 +19,6 @@
 #include "native_client/src/trusted/service_runtime/dyn_array.h"
 #include "native_client/src/trusted/service_runtime/nacl_app.h"
 #include "native_client/src/trusted/service_runtime/nacl_desc_effector_ldr.h"
-#include "native_client/src/trusted/service_runtime/nacl_globals.h"
 #include "native_client/src/trusted/service_runtime/nacl_stack_safety.h"
 #include "native_client/src/trusted/service_runtime/nacl_switch_to_app.h"
 #include "native_client/src/trusted/service_runtime/nacl_syscall_common.h"

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -19,6 +19,7 @@
 #include "native_client/src/trusted/service_runtime/dyn_array.h"
 #include "native_client/src/trusted/service_runtime/nacl_app.h"
 #include "native_client/src/trusted/service_runtime/nacl_desc_effector_ldr.h"
+#include "native_client/src/trusted/service_runtime/nacl_globals.h"
 #include "native_client/src/trusted/service_runtime/nacl_stack_safety.h"
 #include "native_client/src/trusted/service_runtime/nacl_switch_to_app.h"
 #include "native_client/src/trusted/service_runtime/nacl_syscall_common.h"

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -45,7 +45,7 @@ int cagecount;
  * of the parents NaClApp structure which is
  * used in NaClSysFork()
  */
-struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id) {
+struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id, enum NaClThreadLaunchType tl_type) {
   struct NaClApp *nap_child = NaClAlignedMalloc(sizeof(*nap_child), __alignof(struct NaClApp));
   struct NaClApp *nap_parent = nap;
   NaClErrorCode *mod_status = NULL;
@@ -62,6 +62,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id) {
   }
 
   mod_status = &nap_child->module_load_status;
+  nap_child->tl_type = tl_type;     /* Set nap's thread launch type */
   nap_child->argc = nap_parent->argc;
   nap_child->argv = nap_parent->argv;
   nap_child->binary = nap_parent->binary;

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -15,7 +15,6 @@
 #include "native_client/src/shared/platform/nacl_exit.h"
 #include "native_client/src/shared/platform/nacl_sync_checked.h"
 
-#include "native_client/src/trusted/service_runtime/sel_ldr.h"
 #include "native_client/src/trusted/service_runtime/arch/sel_ldr_arch.h"
 #include "native_client/src/trusted/service_runtime/dyn_array.h"
 #include "native_client/src/trusted/service_runtime/nacl_app.h"

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -15,6 +15,7 @@
 #include "native_client/src/shared/platform/nacl_exit.h"
 #include "native_client/src/shared/platform/nacl_sync_checked.h"
 
+#include "native_client/src/trusted/service_runtime/sel_ldr.h"
 #include "native_client/src/trusted/service_runtime/arch/sel_ldr_arch.h"
 #include "native_client/src/trusted/service_runtime/dyn_array.h"
 #include "native_client/src/trusted/service_runtime/nacl_app.h"

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -18,6 +18,7 @@
 #include "native_client/src/shared/platform/nacl_threads.h"
 #include "native_client/src/trusted/service_runtime/nacl_signal.h"
 #include "native_client/src/trusted/service_runtime/sel_rt.h"
+#include "native_client/src/trusted/service_runtime/nacl_globals.h"
 
 
 EXTERN_C_BEGIN

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -150,7 +150,7 @@ struct NaClAppThread {
   int                       dynamic_delete_generation;
 };
 
-struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id);
+struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id, enum NaClThreadLaunchType tl_type);
 
 void WINAPI NaClAppThreadLauncher(void *state);
 

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -18,7 +18,6 @@
 #include "native_client/src/shared/platform/nacl_threads.h"
 #include "native_client/src/trusted/service_runtime/nacl_signal.h"
 #include "native_client/src/trusted/service_runtime/sel_rt.h"
-#include "native_client/src/trusted/service_runtime/nacl_globals.h"
 
 
 EXTERN_C_BEGIN

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -26,6 +26,13 @@ EXTERN_C_BEGIN
 struct NaClApp;
 struct NaClAppThreadSuspendedRegisters;
 
+enum NaClThreadLaunchType {
+  THREAD_LAUNCH_MAIN,
+  THREAD_LAUNCH_FORK,
+  THREAD_LAUNCH_EXEC
+};
+
+
 /*
  * The thread hosting the NaClAppThread may change suspend_state
  * between NACL_APP_THREAD_TRUSTED and NACL_APP_THREAD_UNTRUSTED using

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -18,7 +18,13 @@
 #include "native_client/src/shared/platform/nacl_threads.h"
 #include "native_client/src/trusted/service_runtime/nacl_signal.h"
 #include "native_client/src/trusted/service_runtime/sel_rt.h"
-#include "native_client/src/trusted/service_runtime/sel_ldr.h"
+
+
+enum NaClThreadLaunchType {
+  THREAD_LAUNCH_MAIN,
+  THREAD_LAUNCH_FORK,
+  THREAD_LAUNCH_EXEC
+};
 
 
 EXTERN_C_BEGIN

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -18,6 +18,7 @@
 #include "native_client/src/shared/platform/nacl_threads.h"
 #include "native_client/src/trusted/service_runtime/nacl_signal.h"
 #include "native_client/src/trusted/service_runtime/sel_rt.h"
+#include "native_client/src/trusted/service_runtime/sel_ldr.h"
 
 
 EXTERN_C_BEGIN

--- a/src/trusted/service_runtime/nacl_app_thread.h
+++ b/src/trusted/service_runtime/nacl_app_thread.h
@@ -20,13 +20,6 @@
 #include "native_client/src/trusted/service_runtime/sel_rt.h"
 
 
-enum NaClThreadLaunchType {
-  THREAD_LAUNCH_MAIN,
-  THREAD_LAUNCH_FORK,
-  THREAD_LAUNCH_EXEC
-};
-
-
 EXTERN_C_BEGIN
 
 struct NaClApp;

--- a/src/trusted/service_runtime/nacl_globals.h
+++ b/src/trusted/service_runtime/nacl_globals.h
@@ -54,12 +54,6 @@ struct NaClAppThread;
 struct NaClMutex;
 struct NaClApp;
 
-enum NaClThreadLaunchType {
-  THREAD_LAUNCH_MAIN,
-  THREAD_LAUNCH_FORK,
-  THREAD_LAUNCH_EXEC
-};
-
 /*
  * always points at original program context
  */

--- a/src/trusted/service_runtime/nacl_globals.h
+++ b/src/trusted/service_runtime/nacl_globals.h
@@ -54,6 +54,12 @@ struct NaClAppThread;
 struct NaClMutex;
 struct NaClApp;
 
+enum NaClThreadLaunchType {
+  THREAD_LAUNCH_MAIN,
+  THREAD_LAUNCH_FORK,
+  THREAD_LAUNCH_EXEC
+};
+
 /*
  * always points at original program context
  */

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4085,7 +4085,7 @@ int32_t NaClSysFork(struct NaClAppThread *natp) {
   lind_fork(child_cage_id, nap->cage_id); 
   NaClXMutexUnlock(&nap->mu);
 
-  nap_child = NaClChildNapCtor(natp->nap, child_cage_id, THREAD_LAUNCH_EXEC);
+  nap_child = NaClChildNapCtor(natp->nap, child_cage_id, THREAD_LAUNCH_FORK);
   child_argc = nap_child->argc;
   child_argv = nap_child->argv;
   nap_child->running = 0;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4085,14 +4085,14 @@ int32_t NaClSysFork(struct NaClAppThread *natp) {
   lind_fork(child_cage_id, nap->cage_id); 
   NaClXMutexUnlock(&nap->mu);
 
-  nap_child = NaClChildNapCtor(natp->nap, child_cage_id);
+  nap_child = NaClChildNapCtor(natp->nap, child_cage_id, THREAD_LAUNCH_EXEC);
   child_argc = nap_child->argc;
   child_argv = nap_child->argv;
   nap_child->running = 0;
   ret = child_cage_id;
 
   /* start fork thread */
-  if (!NaClCreateThread(THREAD_LAUNCH_FORK, natp, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+  if (!NaClCreateThread(natp, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
     NaClLog(1, "%s\n", "[NaClSysFork] forking program failed!");
     ret = -NACL_ABI_ENOMEM;
 
@@ -4247,7 +4247,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   lind_exec(child_cage_id, nap->cage_id);
   NaClXMutexUnlock(&nap->mu);
 
-  nap_child = NaClChildNapCtor(nap, child_cage_id);
+  nap_child = NaClChildNapCtor(nap, child_cage_id, THREAD_LAUNCH_EXEC);
   nap_child->running = 0;
   nap_child->in_fork = 0;
 
@@ -4373,7 +4373,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   /* execute new binary, we pass NULL as parent natp since we're not basing the new thread off of this one. */
   ret = -NACL_ABI_ENOEXEC;
   NaClLog(1, "binary = %s\n", nap->binary);
-  if (!NaClCreateThread(THREAD_LAUNCH_EXEC, NULL, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
+  if (!NaClCreateThread(NULL, nap_child, child_argc, child_argv, nap_child->clean_environ)) {
     NaClLog(LOG_ERROR, "%s\n", "NaClCreateThread() failed");
     NaClEnvCleanserDtor(&env_cleanser);
     /* remove child cage */

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -641,8 +641,7 @@ uintptr_t NaClGetInitialStackTop(struct NaClApp *nap);
  */
 
 
-int NaClCreateThread(enum NaClThreadLaunchType tl_type,
-                     struct NaClAppThread     *natp_parent,
+int NaClCreateThread(struct NaClAppThread     *natp_parent,
                      struct NaClApp           *nap_child,
                      int                      argc,
                      char                     **argv,

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -118,12 +118,6 @@ struct NaClSpringboardInfo {
   uint32_t end_addr;
 };
 
-enum NaClThreadLaunchType {
-  THREAD_LAUNCH_MAIN,
-  THREAD_LAUNCH_FORK,
-  THREAD_LAUNCH_EXEC
-};
-
 struct NaClApp {
   /*
    * children table lock children_mu is higher in the locking order than

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -250,7 +250,9 @@ NaClErrorCode NaClAppLoadFileAslr(struct NaClDesc *ndp,
    * the linux-style brk system call (which returns current break on
    * failure) permits a non-aligned address as argument.
    */
-  nap->break_addr = max_vaddr;
+  
+  if (nap->parent) nap->break_addr = nap->parent->break_addr;
+  else nap->break_addr = max_vaddr;
   nap->data_end = max_vaddr;
 
   NaClLog(4, "Values from NaClElfImageValidateProgramHeaders:\n");

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -710,6 +710,9 @@ NaClCreateThread(struct NaClAppThread     *natp_parent,
   size = 0;
   envc = 0;
 
+  enum NaClThreadLaunchType tl_type = nap_child->tl_type;
+
+
   if (tl_type == THREAD_LAUNCH_FORK){
 
     nap_parent = natp_parent->nap;

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -679,8 +679,7 @@ uintptr_t NaClGetInitialStackTop(struct NaClApp *nap) {
   * envv may be NULL (this happens on MacOS/Cocoa and in tests)
   * if envv is non-NULL it is 'consistent', null terminated etc.
   */
-NaClCreateThread(enum NaClThreadLaunchType tl_type,
-                struct NaClAppThread     *natp_parent,
+NaClCreateThread(struct NaClAppThread     *natp_parent,
                 struct NaClApp           *nap_child,
                 int                      argc,
                 char                     **argv,
@@ -710,10 +709,6 @@ NaClCreateThread(enum NaClThreadLaunchType tl_type,
   retval = 0;
   size = 0;
   envc = 0;
-
-  /* Set nap's thread launch type */
-  nap_child->tl_type = tl_type;
-
 
   if (tl_type == THREAD_LAUNCH_FORK){
 

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -250,8 +250,8 @@ NaClErrorCode NaClAppLoadFileAslr(struct NaClDesc *ndp,
    * the linux-style brk system call (which returns current break on
    * failure) permits a non-aligned address as argument.
    */
-  
-  if (nap->parent) nap->break_addr = nap->parent->break_addr;
+
+  if (nap->tl_type == THREAD_LAUNCH_FORK) nap->break_addr = nap->parent->break_addr;
   else nap->break_addr = max_vaddr;
   nap->data_end = max_vaddr;
 

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -863,8 +863,8 @@ int NaClSelLdrMain(int argc, char **argv) {
   NaClLog(1, "%s\n\n", "[NaCl Main Loader] before creation of the cage to run user program!");
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
   nacl_initialization_finish = LindGetTime();
-  if (!NaClCreateThread(THREAD_LAUNCH_MAIN,
-                        NULL,
+  nap->tl_type = THREAD_LAUNCH_MAIN; //set main thread
+  if (!NaClCreateThread(NULL,
                         nap,
                         argc - optind,
                         argv + optind,

--- a/src/trusted/service_runtime/sel_main_chrome.c
+++ b/src/trusted/service_runtime/sel_main_chrome.c
@@ -353,10 +353,10 @@ void NaClChromeMainStart(struct NaClChromeMainArgs *args) {
 
   free(args);
   args = NULL;
-
+  nap->tl_type = THREAD_LAUNCH_MAIN;
   if (NACL_FI_ERROR_COND(
           "NaClCreateThread",
-          !NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, nap, ac, av,
+          !NaClCreateThread(NULL, nap, ac, av,
                                 NaClEnvCleanserEnvironment(&env_cleanser)))) {
     NaClLog(LOG_FATAL, "creating main thread failed\n");
   }

--- a/tests/custom_desc/desc_test_host.c
+++ b/tests/custom_desc/desc_test_host.c
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
   g_nap = &app;
   g_expected_desc = MakeExampleDesc();
   NaClSetDesc(&app, 10, g_expected_desc);
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
   CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));

--- a/tests/custom_desc/desc_test_host.c
+++ b/tests/custom_desc/desc_test_host.c
@@ -194,7 +194,7 @@ int main(int argc, char **argv) {
   g_nap = &app;
   g_expected_desc = MakeExampleDesc();
   NaClSetDesc(&app, 10, g_expected_desc);
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
   CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));

--- a/tests/custom_desc/desc_test_host.c
+++ b/tests/custom_desc/desc_test_host.c
@@ -194,9 +194,10 @@ int main(int argc, char **argv) {
   g_nap = &app;
   g_expected_desc = MakeExampleDesc();
   NaClSetDesc(&app, 10, g_expected_desc);
+  &app.tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   /* Check for leaks. */

--- a/tests/faulted_thread_queue/faultqueue_test_host.c
+++ b/tests/faulted_thread_queue/faultqueue_test_host.c
@@ -104,8 +104,9 @@ struct NaClSignalContext *StartGuestWithSharedMemory(
   expected_regs = (struct NaClSignalContext *) NaClUserToSys(nap, mmap_addr);
 
   WaitForThreadToExitFully(nap);
+  nap->tl_type = THREAD_LAUNCH_MAIN;
 
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
+  CHECK(NaClCreateThread(NULL, nap, NACL_ARRAY_SIZE(args), args, NULL));
   return expected_regs;
 }
 

--- a/tests/minnacl/minimal_test_host.c
+++ b/tests/minnacl/minimal_test_host.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
   CHECK(NaClAppWithSyscallTableCtor(&app, syscall_table));
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   /* These are examples of two different ways to run untrusted code. */
   if (use_separate_thread) {

--- a/tests/minnacl/minimal_test_host.c
+++ b/tests/minnacl/minimal_test_host.c
@@ -69,7 +69,7 @@ int main(int argc, char **argv) {
   CHECK(NaClAppWithSyscallTableCtor(&app, syscall_table));
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
   /* These are examples of two different ways to run untrusted code. */
   if (use_separate_thread) {

--- a/tests/minnacl/minimal_test_host.c
+++ b/tests/minnacl/minimal_test_host.c
@@ -69,11 +69,12 @@ int main(int argc, char **argv) {
   CHECK(NaClAppWithSyscallTableCtor(&app, syscall_table));
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
+  &app.tl_type = THREAD_LAUNCH_MAIN;
 
   /* These are examples of two different ways to run untrusted code. */
   if (use_separate_thread) {
     /* Create a new host thread that is managed by NaCl. */
-    CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
+    CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
     NaClWaitForMainThreadToExit(&app);
 
     NaClLog(LOG_FATAL, "The exit syscall is not supposed to be callable\n");

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -76,8 +76,11 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[0], handle_pair[0], SEND_DESC);
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app[0], 2, domain1_args, NULL));
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app[1], 2, domain2_args, NULL));
+  &app[0].tl_type = THREAD_LAUNCH_MAIN;
+
+
+  CHECK(NaClCreateThread(NULL, &app[0], 2, domain1_args, NULL));
+  CHECK(NaClCreateThread(NULL, &app[1], 2, domain2_args, NULL));
 
   return_code = NaClWaitForMainThreadToExit(&app[0]);
   CHECK(return_code == 101);

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[0], handle_pair[0], SEND_DESC);
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
-  app[0]->tl_type = THREAD_LAUNCH_MAIN;
-  app[1]->tl_type = THREAD_LAUNCH_MAIN;
+  app[0].tl_type = THREAD_LAUNCH_MAIN;
+  app[1].tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app[0], 2, domain1_args, NULL));
   CHECK(NaClCreateThread(NULL, &app[1], 2, domain2_args, NULL));

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -76,8 +76,8 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[0], handle_pair[0], SEND_DESC);
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
-  &app[0].tl_type = THREAD_LAUNCH_MAIN;
-  &app[1].tl_type = THREAD_LAUNCH_MAIN;
+  app[0]->tl_type = THREAD_LAUNCH_MAIN;
+  app[1]->tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app[0], 2, domain1_args, NULL));
   CHECK(NaClCreateThread(NULL, &app[1], 2, domain2_args, NULL));

--- a/tests/multiple_sandboxes/multidomain_test_host.c
+++ b/tests/multiple_sandboxes/multidomain_test_host.c
@@ -77,7 +77,7 @@ int main(int argc, char **argv) {
   NaClAddImcHandle(&app[1], handle_pair[1], RECEIVE_DESC);
 
   &app[0].tl_type = THREAD_LAUNCH_MAIN;
-
+  &app[1].tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app[0], 2, domain1_args, NULL));
   CHECK(NaClCreateThread(NULL, &app[1], 2, domain2_args, NULL));

--- a/tests/signal_handler_single_step/regs_step_test_host.c
+++ b/tests/signal_handler_single_step/regs_step_test_host.c
@@ -337,7 +337,9 @@ int main(int argc, char **argv) {
   g_test_shm = (struct RegsTestShm *) NaClUserToSys(&app, mmap_addr);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
 
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 2, args, NULL));
+  &app.tl_type = THREAD_LAUNCH_MAIN;
+
+  CHECK(NaClCreateThread(NULL, &app, 2, args, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/regs_step_test_host.c
+++ b/tests/signal_handler_single_step/regs_step_test_host.c
@@ -337,7 +337,7 @@ int main(int argc, char **argv) {
   g_test_shm = (struct RegsTestShm *) NaClUserToSys(&app, mmap_addr);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
 
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, 2, args, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);

--- a/tests/signal_handler_single_step/regs_step_test_host.c
+++ b/tests/signal_handler_single_step/regs_step_test_host.c
@@ -337,7 +337,7 @@ int main(int argc, char **argv) {
   g_test_shm = (struct RegsTestShm *) NaClUserToSys(&app, mmap_addr);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
 
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, 2, args, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
   NaClSignalHandlerInit();
   NaClSignalHandlerSet(TrapSignalHandler);
 
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
 
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -169,9 +169,12 @@ int main(int argc, char **argv) {
   NaClSignalHandlerInit();
   NaClSignalHandlerSet(TrapSignalHandler);
 
+  &app.tl_type = THREAD_LAUNCH_MAIN;
+
+
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
+  CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   CHECK(!g_in_untrusted_code);

--- a/tests/signal_handler_single_step/step_test_host.c
+++ b/tests/signal_handler_single_step/step_test_host.c
@@ -169,7 +169,7 @@ int main(int argc, char **argv) {
   NaClSignalHandlerInit();
   NaClSignalHandlerSet(TrapSignalHandler);
 
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
 
   CHECK(NaClAppLoadFileFromFilename(&app, argv[1]) == LOAD_OK);

--- a/tests/thread_suspension/suspend_test_host.c
+++ b/tests/thread_suspension/suspend_test_host.c
@@ -82,10 +82,11 @@ static struct SuspendTestShm *StartGuestWithSharedMemory(
       NACL_ABI_MAP_PRIVATE | NACL_ABI_MAP_ANONYMOUS,
       -1, 0);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
+  nap->tl_type = THREAD_LAUNCH_MAIN;
 
   WaitForThreadToExitFully(nap);
 
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, nap, 3, args, NULL));
+  CHECK(NaClCreateThread(NULL, nap, 3, args, NULL));
   return (struct SuspendTestShm *) NaClUserToSys(nap, mmap_addr);
 }
 

--- a/tests/thread_suspension/suspend_test_host.c
+++ b/tests/thread_suspension/suspend_test_host.c
@@ -82,7 +82,7 @@ static struct SuspendTestShm *StartGuestWithSharedMemory(
       NACL_ABI_MAP_PRIVATE | NACL_ABI_MAP_ANONYMOUS,
       -1, 0);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
-  nap->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   WaitForThreadToExitFully(nap);
 

--- a/tests/thread_suspension/suspend_test_host.c
+++ b/tests/thread_suspension/suspend_test_host.c
@@ -82,7 +82,7 @@ static struct SuspendTestShm *StartGuestWithSharedMemory(
       NACL_ABI_MAP_PRIVATE | NACL_ABI_MAP_ANONYMOUS,
       -1, 0);
   SNPRINTF(arg_string, sizeof(arg_string), "0x%x", (unsigned int) mmap_addr);
-  app.tl_type = THREAD_LAUNCH_MAIN;
+  nap->tl_type = THREAD_LAUNCH_MAIN;
 
   WaitForThreadToExitFully(nap);
 

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -313,7 +313,9 @@ int main(int argc, char **argv) {
 
   RegisterHandlers();
 
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, argc - 1, argv + 1, NULL));
+  &app.tl_type = THREAD_LAUNCH_MAIN;
+
+  CHECK(NaClCreateThread(NULL, &app, argc - 1, argv + 1, NULL));
   NaClWaitForMainThreadToExit(&app);
 
   NaClLog(LOG_ERROR, "We did not expect the test program to exit cleanly\n");

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 
   RegisterHandlers();
 
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, argc - 1, argv + 1, NULL));
   NaClWaitForMainThreadToExit(&app);

--- a/tests/trusted_crash/crash_in_syscall/test_host.c
+++ b/tests/trusted_crash/crash_in_syscall/test_host.c
@@ -313,7 +313,7 @@ int main(int argc, char **argv) {
 
   RegisterHandlers();
 
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, argc - 1, argv + 1, NULL));
   NaClWaitForMainThreadToExit(&app);

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -145,7 +145,9 @@ int main(int argc, char **argv) {
 
   RegisterExceptionHandler();
 
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
+  &app.tl_type = THREAD_LAUNCH_MAIN;
+
+  CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   NaClWaitForMainThreadToExit(&app);
   NaClLog(LOG_FATAL, "Did not expect the guest code to exit\n");
   return 1;

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
   RegisterExceptionHandler();
 
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   NaClWaitForMainThreadToExit(&app);

--- a/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
+++ b/tests/trusted_crash/osx_crash_filter/crash_filter_test.c
@@ -145,7 +145,7 @@ int main(int argc, char **argv) {
 
   RegisterExceptionHandler();
 
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   NaClWaitForMainThreadToExit(&app);

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
   CHECK(NaClAppLoadFileFromFilename(&app, argv[2]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
 
-  &app.tl_type = THREAD_LAUNCH_MAIN;
+  app->tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -158,7 +158,7 @@ int main(int argc, char **argv) {
   CHECK(NaClAppLoadFileFromFilename(&app, argv[2]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
 
-  app->tl_type = THREAD_LAUNCH_MAIN;
+  app.tl_type = THREAD_LAUNCH_MAIN;
 
   CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);

--- a/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
+++ b/tests/trusted_crash/osx_crash_forwarding/mach_crash_forwarding_test.c
@@ -157,7 +157,10 @@ int main(int argc, char **argv) {
   app.enable_exception_handling = 1;
   CHECK(NaClAppLoadFileFromFilename(&app, argv[2]) == LOAD_OK);
   CHECK(NaClAppPrepareToLaunch(&app) == LOAD_OK);
-  CHECK(NaClCreateThread(THREAD_LAUNCH_MAIN, NULL, &app, 0, NULL, NULL));
+
+  &app.tl_type = THREAD_LAUNCH_MAIN;
+
+  CHECK(NaClCreateThread(NULL, &app, 0, NULL, NULL));
   CHECK(NaClWaitForMainThreadToExit(&app) == 0);
 
   if (g_expect_crash) {


### PR DESCRIPTION
This rearranges thread launching to give threads a launch type earlier in execution, its also a bit cleaner. This enables us later on to set the break address for a child to the parent address if it's a fork.