### PR TITLE
Increase IO Efficiency for Read/Write in NaCl

### DIFF
--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -1057,7 +1057,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   sysaddr = NaClUserToSysAddrRange(nap, (uintptr_t) buf, count);
   if (kNaClBadAddress == sysaddr) {
-    // NaClDescUnref(ndp);
+    NaClDescUnref(ndp);
     retval = -NACL_ABI_EFAULT;
     goto out;
   }
@@ -1085,7 +1085,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   write_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Write(ndp, (void *)sysaddr, count);
 
-  // NaClDescUnref(ndp);
+  NaClDescUnref(ndp);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t)write_result;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -895,7 +895,9 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
     goto out;
   }
 
-  ndp = NaClGetDesc(nap, fd);
+  // ndp = NaClGetDesc(nap, fd);
+  ndp = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, fd);
+
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
   if (!ndp) {
     retval = -NACL_ABI_EBADF;
@@ -937,7 +939,7 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   } else {
     NaClLog(4, "read returned %"NACL_PRIdS"\n", read_result);
   }
-  NaClDescUnref(ndp);
+  // NaClDescUnref(ndp);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t) read_result;
@@ -1048,7 +1050,9 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
     goto out;
   }
 
-  ndp = NaClGetDesc(nap, fd);
+  // ndp = NaClGetDesc(nap, fd);
+  ndp = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, fd);
+
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
   if (!ndp) {
     retval = -NACL_ABI_EBADF;
@@ -1085,7 +1089,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   write_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Write(ndp, (void *)sysaddr, count);
 
-  NaClDescUnref(ndp);
+  // NaClDescUnref(ndp);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t)write_result;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -290,17 +290,15 @@ int32_t NaClOpenAclCheck(struct NaClApp *nap,
    */
   NaClLog(1, "NaClOpenAclCheck(0x%08"NACL_PRIxPTR", %s, 0%o, 0%o)\n",
           (uintptr_t) nap, path, flags, mode);
-  if (3 < NaClLogGetVerbosity()) {
-    NaClLog(0, "O_ACCMODE: 0%o\n", flags & NACL_ABI_O_ACCMODE);
-    NaClLog(0, "O_RDONLY = %d\n", NACL_ABI_O_RDONLY);
-    NaClLog(0, "O_WRONLY = %d\n", NACL_ABI_O_WRONLY);
-    NaClLog(0, "O_RDWR   = %d\n", NACL_ABI_O_RDWR);
+  NaClLog(4, "O_ACCMODE: 0%o\n", flags & NACL_ABI_O_ACCMODE);
+  NaClLog(4, "O_RDONLY = %d\n", NACL_ABI_O_RDONLY);
+  NaClLog(4, "O_WRONLY = %d\n", NACL_ABI_O_WRONLY);
+  NaClLog(4, "O_RDWR   = %d\n", NACL_ABI_O_RDWR);
 #define FLOG(VAR, BIT) NaClLog(1, "%s: %s\n", #BIT, ((VAR) & (BIT)) ? "yes" : "no")
     FLOG(flags, NACL_ABI_O_CREAT);
     FLOG(flags, NACL_ABI_O_TRUNC);
     FLOG(flags, NACL_ABI_O_APPEND);
 #undef FLOG
-  }
   if (NaClAclBypassChecks) {
     return 0;
   }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -895,7 +895,6 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
     goto out;
   }
 
-  // ndp = NaClGetDesc(nap, fd);
   ndp = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, fd);
 
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
@@ -939,7 +938,6 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   } else {
     NaClLog(4, "read returned %"NACL_PRIdS"\n", read_result);
   }
-  // NaClDescUnref(ndp);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t) read_result;
@@ -1050,7 +1048,6 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
     goto out;
   }
 
-  // ndp = NaClGetDesc(nap, fd);
   ndp = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, fd);
 
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
@@ -1088,8 +1085,6 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
 
   write_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Write(ndp, (void *)sysaddr, count);
-
-  // NaClDescUnref(ndp);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t)write_result;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -930,11 +930,9 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
       log_bytes = INT32_MAX;
       ellipsis = "...";
     }
-    if (NaClLogGetVerbosity() < 10) {
-      if (log_bytes > kdefault_io_buffer_bytes_to_log) {
-        log_bytes = kdefault_io_buffer_bytes_to_log;
-        ellipsis = "...";
-      }
+    if (log_bytes > kdefault_io_buffer_bytes_to_log) {
+      log_bytes = kdefault_io_buffer_bytes_to_log;
+      ellipsis = "...";
     }
     NaClLog(8, "read result: %.*s%s\n",
             (int) log_bytes, (char *) sysaddr, ellipsis);
@@ -1012,11 +1010,9 @@ int32_t NaClSysPread(struct NaClAppThread  *natp, //will make NaCl logs like rea
       log_bytes = INT32_MAX;
       ellipsis = "...";
     }
-    if (NaClLogGetVerbosity() < 10) {
-      if (log_bytes > kdefault_io_buffer_bytes_to_log) {
-        log_bytes = kdefault_io_buffer_bytes_to_log;
-        ellipsis = "...";
-      }
+    if (log_bytes > kdefault_io_buffer_bytes_to_log) {
+      log_bytes = kdefault_io_buffer_bytes_to_log;
+      ellipsis = "...";
     }
     NaClLog(8, "pread result: %.*s%s\n",
             (int) log_bytes, (char *) sysaddr, ellipsis);
@@ -1079,7 +1075,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
     ellipsis = "...";
   }
   UNREFERENCED_PARAMETER(ellipsis);
-  if (NaClLogGetVerbosity() < 10 && log_bytes > kdefault_io_buffer_bytes_to_log) {
+  if (log_bytes > kdefault_io_buffer_bytes_to_log) {
      log_bytes = kdefault_io_buffer_bytes_to_log;
      ellipsis = "...";
   }
@@ -1149,7 +1145,7 @@ int32_t NaClSysPwrite(struct NaClAppThread *natp,
     ellipsis = "...";
   }
   UNREFERENCED_PARAMETER(ellipsis);
-  if (NaClLogGetVerbosity() < 10 && log_bytes > kdefault_io_buffer_bytes_to_log) {
+  if (log_bytes > kdefault_io_buffer_bytes_to_log) {
      log_bytes = kdefault_io_buffer_bytes_to_log;
      ellipsis = "...";
   }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -920,14 +920,9 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
     count = INT32_MAX;
   }
 
-  NaClVmIoWillStart(nap,
-                    (uint32_t) (uintptr_t) buf,
-                    (uint32_t) (((uintptr_t) buf) + count - 1));
+
   read_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Read(ndp, (void *)sysaddr, count);
 
-  NaClVmIoHasEnded(nap,
-                    (uint32_t) (uintptr_t) buf,
-                    (uint32_t) (((uintptr_t) buf) + count - 1));
   if (read_result > 0) {
     NaClLog(4, "read returned %"NACL_PRIdS" bytes\n", read_result);
     log_bytes = (size_t) read_result;
@@ -1093,14 +1088,8 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   NaClLog(2, "In NaClSysWrite(%d, %.*s%s, %"NACL_PRIdS")\n",
           d, (int)log_bytes, (char *)sysaddr, ellipsis, count);
 
-  NaClVmIoWillStart(nap,
-                    (uint32_t)(uintptr_t)buf,
-                    (uint32_t)(((uintptr_t)buf) + count - 1));
-  write_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Write(ndp, (void *)sysaddr, count);
 
-  NaClVmIoHasEnded(nap,
-                   (uint32_t)(uintptr_t)buf,
-                   (uint32_t)(((uintptr_t)buf) + count - 1));
+  write_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Write(ndp, (void *)sysaddr, count);
 
   NaClDescUnref(ndp);
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -896,7 +896,7 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   }
 
   ndp = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, fd);
-
+  /* Use DynArrayGet to bypass GetDesc locks for fast IO */
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
   if (!ndp) {
     retval = -NACL_ABI_EBADF;
@@ -918,7 +918,6 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   if (count > INT32_MAX) {
     count = INT32_MAX;
   }
-
 
   read_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Read(ndp, (void *)sysaddr, count);
 
@@ -1049,7 +1048,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   }
 
   ndp = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, fd);
-
+  /* Use DynArrayGet to bypass GetDesc locks for fast IO */
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
   if (!ndp) {
     retval = -NACL_ABI_EBADF;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -1057,7 +1057,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   sysaddr = NaClUserToSysAddrRange(nap, (uintptr_t) buf, count);
   if (kNaClBadAddress == sysaddr) {
-    NaClDescUnref(ndp);
+    // NaClDescUnref(ndp);
     retval = -NACL_ABI_EFAULT;
     goto out;
   }
@@ -1085,7 +1085,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   write_result = ((struct NaClDescVtbl const *)ndp->base.vtbl)->Write(ndp, (void *)sysaddr, count);
 
-  NaClDescUnref(ndp);
+  // NaClDescUnref(ndp);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t)write_result;

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -625,9 +625,7 @@ struct NaClDesc *NaClGetDesc(struct NaClApp *nap,
                              int            d) {
   struct NaClDesc *res;
 
-  // NaClFastMutexLock(&nap->desc_mu);
   res = NaClGetDescMu(nap, d);
-  // NaClFastMutexUnlock(&nap->desc_mu);
   return res;
 }
 

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -581,7 +581,7 @@ struct NaClDesc *NaClGetDescMu(struct NaClApp *nap,
 
   result = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, d);
   if (result) {
-    // NaClDescRef(result);
+    NaClDescRef(result);
   }
 
   return result;

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -581,7 +581,7 @@ struct NaClDesc *NaClGetDescMu(struct NaClApp *nap,
 
   result = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, d);
   if (result) {
-    NaClDescRef(result);
+    // NaClDescRef(result);
   }
 
   return result;
@@ -625,9 +625,9 @@ struct NaClDesc *NaClGetDesc(struct NaClApp *nap,
                              int            d) {
   struct NaClDesc *res;
 
-  NaClFastMutexLock(&nap->desc_mu);
+  // NaClFastMutexLock(&nap->desc_mu);
   res = NaClGetDescMu(nap, d);
-  NaClFastMutexUnlock(&nap->desc_mu);
+  // NaClFastMutexUnlock(&nap->desc_mu);
   return res;
 }
 

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -587,6 +587,15 @@ struct NaClDesc *NaClGetDescMu(struct NaClApp *nap,
   return result;
 }
 
+struct NaClDesc *NaClGetDescMuNoRef(struct NaClApp *nap,
+                               int            d) {
+  struct NaClDesc *result;
+
+  result = (struct NaClDesc *) DynArrayGet(&nap->desc_tbl, d);
+
+  return result;
+}
+
 void NaClSetDescMu(struct NaClApp   *nap,
                    int              d,
                    struct NaClDesc  *ndp) {

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -686,6 +686,9 @@ int32_t NaClSetAvail(struct NaClApp   *nap,
 struct NaClDesc *NaClGetDescMu(struct NaClApp *nap,
                                int            d);
 
+struct NaClDesc *NaClGetDescMuNoRef(struct NaClApp *nap,
+                                    int            d);
+
 void NaClSetDescMu(struct NaClApp   *nap,
                    int              d,
                    struct NaClDesc  *ndp);
@@ -853,6 +856,11 @@ void NaClVmHoleClosingMu(struct NaClApp *nap);
  * concurrent "read" and "write" syscalls racing on the same memory
  * region..
  */
+
+/* Lind
+ * We're not only using Linux so it's fine to disregard these operations which are
+ * Windows specific. 
+ * /
 
 /*
  * Some potentially blocking I/O operation is about to start.  Syscall

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -858,7 +858,7 @@ void NaClVmHoleClosingMu(struct NaClApp *nap);
  */
 
 /* Lind
- * We're not only using Linux so it's fine to disregard these operations which are
+ * We're only using Linux so it's fine to disregard these operations which are
  * Windows specific. 
  * /
 


### PR DESCRIPTION
- Gets rid of/bypasses some locks that are not necessary due to RustPOSIX
- Gets rid of VMIOWillStart/Stop which is also unnecessary for us
- Rearranges some logging so it isn't slow for no reason