### PR TITLE
(F/L)Stat fix

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -118,7 +118,7 @@ int lind_rmdir (const char *path, int cageid) {
     DISPATCH_SYSCALL_1(LIND_safe_fs_rmdir, cstr, path);
 }
 
-int lind_xstat (const char *path, struct stat *buf, int cageid) {
+int lind_xstat (const char *path, struct lind_stat *buf, int cageid) {
     DISPATCH_SYSCALL_2(LIND_safe_fs_xstat, cstr, path, statstruct, buf);
 }
 
@@ -142,7 +142,7 @@ int lind_lseek (int fd, off_t offset, int whence, int cageid) {
     DISPATCH_SYSCALL_3(LIND_safe_fs_lseek, int, fd, off_t, offset, int, whence);
 }
 
-int lind_fxstat (int fd, struct stat *buf, int cageid) {
+int lind_fxstat (int fd, struct lind_stat *buf, int cageid) {
     DISPATCH_SYSCALL_2(LIND_safe_fs_fxstat, int, fd, statstruct, buf);
 }
 

--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -14,7 +14,7 @@
 #if NACL_LINUX
 # include <sys/statfs.h>
 #endif
-#include <sys/stat.h>
+#include "native_client/src/shared/platform/lind_stat.h"
 #include <sys/socket.h>
 #include <sys/select.h>
 #include <sys/poll.h>
@@ -113,7 +113,7 @@ union RustArg {
     const char *dispatch_cstr;
     const char *const *dispatch_cstrarr;
     struct rlimit *strdispatch_rlimitstruct;
-    struct stat *dispatch_statstruct;
+    struct lind_stat *dispatch_statstruct;
     struct statfs *dispatch_statfsstruct;
     struct timeval *dispatch_timevalstruct;
     struct sockaddr *dispatch_sockaddrstruct;
@@ -135,13 +135,13 @@ int lind_access (const char *file, int mode, int cageid);
 int lind_chdir (const char *name, int cageid);
 int lind_mkdir (const char *path, int mode, int cageid);
 int lind_rmdir (const char *path, int cageid);
-int lind_xstat (const char *path, struct stat *buf, int cageid);
+int lind_xstat (const char *path, struct lind_stat *buf, int cageid);
 int lind_open (const char *path, int flags, int mode, int cageid);
 int lind_close (int fd, int cageid);
 int lind_read (int fd, void *buf, int size, int cageid);
 int lind_write (int fd, const void *buf, size_t count, int cageid);
 int lind_lseek (int fd, off_t offset, int whence, int cageid);
-int lind_fxstat (int fd, struct stat *buf, int cageid);
+int lind_fxstat (int fd, struct lind_stat *buf, int cageid);
 int lind_fstatfs (int fd, struct statfs *buf, int cageid);
 int lind_statfs (const char *path, struct statfs *buf, int cageid);
 int lind_dup (int oldfd, int cageid);

--- a/src/shared/platform/lind_stat.h
+++ b/src/shared/platform/lind_stat.h
@@ -1,5 +1,6 @@
 /*
- * lind_stat.h *
+ * lind_stat.h 
+ *
  *  Created on: Jul 24, 2013
  *      Author: sji
  */

--- a/src/shared/platform/lind_stat.h
+++ b/src/shared/platform/lind_stat.h
@@ -1,6 +1,5 @@
 /*
- * 
- *
+ * lind_stat.h *
  *  Created on: Jul 24, 2013
  *      Author: sji
  */

--- a/src/shared/platform/lind_stat.h
+++ b/src/shared/platform/lind_stat.h
@@ -1,5 +1,5 @@
 /*
- * lind_stat.h
+ * 
  *
  *  Created on: Jul 24, 2013
  *      Author: sji
@@ -20,11 +20,10 @@ struct lind_stat
 {
     uint64_t st_dev;     /* Device.  */
     uint64_t st_ino;     /* File serial number.  */
-    uint64_t st_nlink;     /* Link count.  */
     uint32_t st_mode;       /* File mode.  */
+    uint32_t st_nlink;     /* Link count.  */
     uint32_t st_uid;     /* User ID of the file's owner. */
     uint32_t st_gid;     /* Group ID of the file's group.*/
-    int32_t __pad0;
     uint64_t st_rdev;        /* Device number, if device.  */
     int64_t st_size;            /* Size of file, in bytes.  */
     int64_t st_blksize; /* Optimal block size for I/O.  */

--- a/src/shared/platform/lind_stat.h
+++ b/src/shared/platform/lind_stat.h
@@ -1,5 +1,5 @@
 /*
- * lind_stat.h 
+ * lind_stat.h
  *
  *  Created on: Jul 24, 2013
  *      Author: sji

--- a/src/trusted/desc/posix/nacl_desc.c
+++ b/src/trusted/desc/posix/nacl_desc.c
@@ -47,12 +47,9 @@ int32_t NaClAbiStatHostDescStatXlateCtor(struct nacl_abi_stat    *dst,
 
   memset(dst, 0, sizeof *dst);
 
-  dst->nacl_abi_st_dev = 0;
-#if defined(NACL_MASK_INODES)
-  dst->nacl_abi_st_ino = NACL_FAKE_INODE_NUM;
-#else
+  dst->nacl_abi_st_dev = src->st_dev;
   dst->nacl_abi_st_ino = src->st_ino;
-#endif
+
 
   switch (src->st_mode & S_IFMT) {
     case S_IFREG:
@@ -88,12 +85,12 @@ int32_t NaClAbiStatHostDescStatXlateCtor(struct nacl_abi_stat    *dst,
   }
   dst->nacl_abi_st_mode = m;
   dst->nacl_abi_st_nlink = src->st_nlink;
-  dst->nacl_abi_st_uid = -1;  /* not root */
-  dst->nacl_abi_st_gid = -1;  /* not wheel */
-  dst->nacl_abi_st_rdev = 0;
+  dst->nacl_abi_st_uid = src->st_uid;
+  dst->nacl_abi_st_gid = src->st_gid;
+  dst->nacl_abi_st_rdev = src->st_rdev;
   dst->nacl_abi_st_size = (nacl_abi_off_t) src->st_size;
-  dst->nacl_abi_st_blksize = 0;
-  dst->nacl_abi_st_blocks = 0;
+  dst->nacl_abi_st_blksize = src->st_blksize;
+  dst->nacl_abi_st_blocks = src->st_blocks;
   dst->nacl_abi_st_atime = src->st_atime;
   dst->nacl_abi_st_mtime = src->st_mtime;
   dst->nacl_abi_st_ctime = src->st_ctime;

--- a/src/trusted/desc/win/nacl_desc.c
+++ b/src/trusted/desc/win/nacl_desc.c
@@ -40,16 +40,9 @@ int32_t NaClAbiStatHostDescStatXlateCtor(struct nacl_abi_stat   *dst,
     return -NACL_ABI_EOVERFLOW;
   }
 
-  dst->nacl_abi_st_dev = 0;
-#if defined(NACL_MASK_INODES)
-  dst->nacl_abi_st_ino = NACL_FAKE_INODE_NUM;
-#else
+  dst->nacl_abi_st_dev = src->st_dev;
   dst->nacl_abi_st_ino = src->st_ino;
-  /*
-   * MSDN says: st_ino has no meaning on most windows file systems,
-   * but in case windows mounts a Unix filesystem, we copy it anyway.
-   */
-#endif
+
 
   switch (src->st_mode & S_IFMT) {
     case S_IFREG:
@@ -79,12 +72,12 @@ int32_t NaClAbiStatHostDescStatXlateCtor(struct nacl_abi_stat   *dst,
   }
   dst->nacl_abi_st_mode = m;
   dst->nacl_abi_st_nlink = src->st_nlink;
-  dst->nacl_abi_st_uid = -1;  /* not root */
-  dst->nacl_abi_st_gid = -1;  /* not wheel */
-  dst->nacl_abi_st_rdev = 0;
+  dst->nacl_abi_st_uid = src->st_uid;
+  dst->nacl_abi_st_gid = src->gid;
+  dst->nacl_abi_st_rdev = src->rdev;
   dst->nacl_abi_st_size = (nacl_abi_off_t) src->st_size;
-  dst->nacl_abi_st_blksize = 0;
-  dst->nacl_abi_st_blocks = 0;
+  dst->nacl_abi_st_blksize =src->blksize;
+  dst->nacl_abi_st_blocks = src->st_blocks;
   dst->nacl_abi_st_atime = (nacl_abi_time_t) src->st_atime;
   dst->nacl_abi_st_mtime = (nacl_abi_time_t) src->st_mtime;
   dst->nacl_abi_st_ctime = (nacl_abi_time_t) src->st_ctime;


### PR DESCRIPTION
This PR fixes some problems that exist with stat calls.

- Fixes ordering and size of nlink in NaCl struct
- Reverts RPC calls
- Fixes NaClAbiStatHostDescStatXlateCtor, a function that was clobbering the stat results