### PR TITLE
Fix Argument Passing

### DIFF
--- a/src/trusted/service_runtime/env_cleanser.c
+++ b/src/trusted/service_runtime/env_cleanser.c
@@ -142,7 +142,7 @@ int NaClEnvCleanserInit(struct NaClEnvCleanser *self, char const *const *envp,
   if (0 != ((1 + num_env) & ptr_size_mult_overflow_mask)) {
     return 0;
   }
-  ptr_bytes = (1 + num_env) * sizeof(*envp);
+  ptr_bytes = (1 + num_env) * sizeof(char *);
 
   ptr_tbl = (char const **) malloc(ptr_bytes);
   if (NULL == ptr_tbl) {

--- a/src/trusted/service_runtime/env_cleanser.c
+++ b/src/trusted/service_runtime/env_cleanser.c
@@ -14,12 +14,6 @@
 #include "native_client/src/trusted/service_runtime/env_cleanser.h"
 #include "native_client/src/trusted/service_runtime/env_cleanser_test.h"
 
-/*
- * Everything that starts with this prefix is allowed (but the prefix is
- * stripped away).
-*/
-#define NACL_ENV_PREFIX "NACLENV_"
-#define NACL_ENV_PREFIX_LENGTH 8
 
 void NaClEnvCleanserCtor(struct NaClEnvCleanser *self, int with_whitelist) {
   self->with_whitelist = with_whitelist;

--- a/src/trusted/service_runtime/env_cleanser.c
+++ b/src/trusted/service_runtime/env_cleanser.c
@@ -110,7 +110,7 @@ int NaClEnvCleanserInit(struct NaClEnvCleanser *self, char const *const *envp,
    * then n*sizeof(void *) will have an arithmetic overflow.
    */
 
-  if ((NULL == envp || NULL == *envp)|| (NULL == extra_env || NULL == *extra_env)) {
+  if ((NULL == envp || NULL == *envp) && (NULL == extra_env || NULL == *extra_env)) {
     self->cleansed_environ = NULL;
     return 1;
   }

--- a/src/trusted/service_runtime/env_cleanser.c
+++ b/src/trusted/service_runtime/env_cleanser.c
@@ -110,7 +110,7 @@ int NaClEnvCleanserInit(struct NaClEnvCleanser *self, char const *const *envp,
    * then n*sizeof(void *) will have an arithmetic overflow.
    */
 
-  if (NULL == envp || NULL == *envp) {
+  if ((NULL == envp || NULL == *envp) && (NULL == extra_env || NULL == *extra_env)) {
     self->cleansed_environ = NULL;
     return 1;
   }

--- a/src/trusted/service_runtime/env_cleanser.h
+++ b/src/trusted/service_runtime/env_cleanser.h
@@ -17,6 +17,13 @@
 
 EXTERN_C_BEGIN
 
+/*
+ * Everything that starts with this prefix is allowed (but the prefix is
+ * stripped away).
+*/
+#define NACL_ENV_PREFIX "NACLENV_"
+#define NACL_ENV_PREFIX_LENGTH 8
+
 struct NaClEnvCleanser {
   /* private */
   int with_whitelist;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4140,15 +4140,16 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
         break;
       }
     }
-    new_envp[new_envc] = 0;
-    /* We've already cleaned the native environment, so just supply extra args from this syscall */
-    if (!NaClEnvCleanserInit(&env_cleanser, 0, (char const *const *)new_envp)) {
-      NaClLog(LOG_ERROR, "%s\n", "Failed to initialize environment cleanser");
-      NaClEnvCleanserDtor(&env_cleanser);
-      goto fail;
-    }
-    nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
   }
+  
+  new_envp[new_envc] = 0;
+  /* We've already cleaned the native environment, so just supply extra args from this syscall */
+  if (!NaClEnvCleanserInit(&env_cleanser, 0, (char const *const *)new_envp)) {
+    NaClLog(LOG_ERROR, "%s\n", "Failed to initialize environment cleanser");
+    NaClEnvCleanserDtor(&env_cleanser);
+    goto fail;
+  }
+  nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
 
 
 fail:

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -93,8 +93,6 @@
 #define kMaxUsableFileSize (SIZE_MAX >> 1)
 #define MIN(a, b) ((size_t)((a < b) ? a : b))
 
-extern char **environ;
-
 struct NaClDescQuotaInterface;
 struct NaClSyscallTableEntry nacl_syscall[NACL_MAX_SYSCALLS];
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4110,6 +4110,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   uint32_t *sys_envp_ptr = { NULL };
   char **new_envp = 0;
   int new_envc = 0;
+  int ret = -NACL_ABI_ENOMEM;
 
 
   /* Make sys_envp_ptr a NULL array if we were passed NULL by EXECV */
@@ -4161,17 +4162,11 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   }
 
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
-
+  ret = NaClSysExecInternal(natp, path, argv);
 
 fail:
-  for (char **pp = new_envp; pp && *pp; pp++) {
-    free(*pp);
-  }
-  free(new_envp);
 
-  return NaClSysExecInternal(natp, path, argv);
-
-
+  return ret; 
 }
 
 int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *argv) {

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4142,9 +4142,9 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
         break;
       }
       else {
-        new_envp[i] = malloc(NACL_ENV_PREFIX_LENGTH + strlen(env) + 1);
-        strcpy(new_envp[i], NACL_ENV_PREFIX);
-        strcat(new_envp[i], env);
+        int envsize = NACL_ENV_PREFIX_LENGTH + strlen(env) + 1;
+        new_envp[i] = calloc(envsize, sizeof(char);
+        snprintf(new_envp[i], envsize, "%s%s", NACL_ENV_PREFIX, env);
       } 
     
     }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4133,7 +4133,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
       char *env = (void *)NaClUserToSysAddr(nap, (uintptr_t)sys_envp_ptr[i]);
       env = (uintptr_t)env == kNaClBadAddress ? 0 : env;
       if (!env) {
-        new_envp[i] = 0;
+        new_envp[i] = NULL;
         break;
       }
       else {
@@ -4143,7 +4143,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
       } 
     }
   }
-  new_envp[new_envc] = 0;
+  new_envp[new_envc] = NULL;
 
   /* We've already cleaned the native environment, so just supply extra args from this syscall */
   if (!NaClEnvCleanserInit(&env_cleanser, (char const *const *)new_envp, 0)) {
@@ -4187,7 +4187,7 @@ int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *
 
   /* Convert pathname from user path, set binary */
   sys_pathname = NaClUserToSysAddr(nap, path);
-  binary = sys_pathname ? strdup(sys_pathname) : 0;
+  binary = sys_pathname ? strdup(sys_pathname) : NULL;
 
   /* 
     Convert to a Sys Pointer for argv** 
@@ -4234,9 +4234,9 @@ int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *
   child_argv[1] = "--library-path";
   child_argv[2] = "/lib/glibc";
   for (int i = 0; i < new_argc; i++) {
-    child_argv[i + 3] = new_argv[i] ? strdup(new_argv[i]) : 0;
+    child_argv[i + 3] = new_argv[i] ? strdup(new_argv[i]) : NULL;
   }
-  child_argv[child_argc] = 0;
+  child_argv[child_argc] = NULL;
   nap->argc = child_argc;
   nap->argv = child_argv;
   if (binary) {

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4156,6 +4156,11 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   ret = NaClSysExecv(natp, path, argv);
 
 fail:
+  for (char **pp = new_envp; pp && *pp; pp++) {
+    free(*pp);
+  }
+  free(new_envp);
+
   return ret; 
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4110,10 +4110,8 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   int new_envc = 0;
   int ret = -NACL_ABI_ENOMEM;
 
-
   /* Make sys_envp_ptr a NULL array if we were passed NULL by EXECV */
   if (envp) sys_envp_ptr = (uint32_t*)NaClUserToSysAddr(nap, (uintptr_t)envp);
-
 
   NaClLog(1, "%s\n", "[NaClSysExecve] NaCl execve() starts!");
 
@@ -4160,7 +4158,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   }
 
   nap->clean_environ = NaClEnvCleanserEnvironment(&env_cleanser);
-  ret = NaClSysExecInternal(natp, path, argv);
+  ret = NaClSysExecv(natp, path, argv);
 
 fail:
 
@@ -4168,12 +4166,6 @@ fail:
 }
 
 int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *argv) {
-  struct NaClApp *nap = natp->nap;
-
-  return NaClSysExecInternal(natp, path, argv);
-}
-
-int32_t NaClSysExecInternal(struct NaClAppThread *natp, char const *path, char *const *argv) {
   struct NaClApp *nap = natp->nap;
   struct NaClApp *nap_child = 0;
   char *sys_pathname;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4118,13 +4118,11 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   /* set up environment, only do this if we initially were passed an environment*/
   NaClEnvCleanserCtor(&env_cleanser, 0);
   if (envp) {
-  
     /* Count amount of env from acquired NaCl pointer */
     uint32_t *envcountptr = sys_envp_ptr;
     while (envcountptr[new_envc] != NULL) {
       new_envc++;
     }
-
     new_envp = calloc(new_envc + 1, sizeof(*new_envp));
     if (!new_envp) {
       NaClLog(LOG_ERROR, "%s\n", "Failed to allocate new_envv");
@@ -4134,7 +4132,6 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
     for (int i = 0; i < new_envc; i++) {
       char *env = (void *)NaClUserToSysAddr(nap, (uintptr_t)sys_envp_ptr[i]);
       env = (uintptr_t)env == kNaClBadAddress ? 0 : env;
-
       if (!env) {
         new_envp[i] = 0;
         break;
@@ -4144,10 +4141,8 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
         new_envp[i] = calloc(envsize, sizeof(char));
         snprintf(new_envp[i], envsize, "%s%s", NACL_ENV_PREFIX, env);
       } 
-    
     }
   }
-
   new_envp[new_envc] = 0;
 
   /* We've already cleaned the native environment, so just supply extra args from this syscall */
@@ -4161,7 +4156,6 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
   ret = NaClSysExecv(natp, path, argv);
 
 fail:
-
   return ret; 
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4143,7 +4143,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
       }
       else {
         int envsize = NACL_ENV_PREFIX_LENGTH + strlen(env) + 1;
-        new_envp[i] = calloc(envsize, sizeof(char);
+        new_envp[i] = calloc(envsize, sizeof(char));
         snprintf(new_envp[i], envsize, "%s%s", NACL_ENV_PREFIX, env);
       } 
     

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4141,10 +4141,10 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
       }
     }
   }
-  
+
   new_envp[new_envc] = 0;
   /* We've already cleaned the native environment, so just supply extra args from this syscall */
-  if (!NaClEnvCleanserInit(&env_cleanser, 0, (char const *const *)new_envp)) {
+  if (!NaClEnvCleanserInit(&env_cleanser, nap->clean_environ, (char const *const *)new_envp)) {
     NaClLog(LOG_ERROR, "%s\n", "Failed to initialize environment cleanser");
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -93,6 +93,8 @@
 #define kMaxUsableFileSize (SIZE_MAX >> 1)
 #define MIN(a, b) ((size_t)((a < b) ? a : b))
 
+extern char **environ;
+
 struct NaClDescQuotaInterface;
 struct NaClSyscallTableEntry nacl_syscall[NACL_MAX_SYSCALLS];
 
@@ -4144,7 +4146,7 @@ int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const 
 
   new_envp[new_envc] = 0;
   /* We've already cleaned the native environment, so just supply extra args from this syscall */
-  if (!NaClEnvCleanserInit(&env_cleanser, nap->clean_environ, (char const *const *)new_envp)) {
+  if (!NaClEnvCleanserInit(&env_cleanser, environ, (char const *const *)new_envp)) {
     NaClLog(LOG_ERROR, "%s\n", "Failed to initialize environment cleanser");
     NaClEnvCleanserDtor(&env_cleanser);
     goto fail;

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -357,7 +357,6 @@ int32_t NaClSysPipe2(struct NaClAppThread *natp, uint32_t *pipedes, int flags);
 int32_t NaClSysFork(struct NaClAppThread *natp);
 int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, char *const *envp);
 int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *argv);
-int32_t NaClSysExecInternal(struct NaClAppThread *natp, char const *path, char *const *argv);
 
 int32_t NaClSysWaitpid(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options);
 int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc);

--- a/src/trusted/service_runtime/nacl_syscall_common.h
+++ b/src/trusted/service_runtime/nacl_syscall_common.h
@@ -353,9 +353,12 @@ int32_t NaClSysTestCrash(struct NaClAppThread *natp, int crash_type);
 
 int32_t NaClSysPipe(struct NaClAppThread *natp, uint32_t *pipedes);
 int32_t NaClSysPipe2(struct NaClAppThread *natp, uint32_t *pipedes, int flags);
+
 int32_t NaClSysFork(struct NaClAppThread *natp);
 int32_t NaClSysExecve(struct NaClAppThread *natp, char const *path, char *const *argv, char *const *envp);
 int32_t NaClSysExecv(struct NaClAppThread *natp, char const *path, char *const *argv);
+int32_t NaClSysExecInternal(struct NaClAppThread *natp, char const *path, char *const *argv);
+
 int32_t NaClSysWaitpid(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options);
 int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc);
 int32_t NaClSysWait4(struct NaClAppThread *natp, int pid, uint32_t *stat_loc, int options, void *rusage);


### PR DESCRIPTION
This ended up being a bit simpler than I thought.

What this PR does:
1 - Switches the way Execve and Execv interact, with execve now parsing new environment variables and then passing to execv instead of vice versa.

2 - Appends "NACLENV_" to new incoming args in Execve so that they pass through the environment cleanser, and sends those args to the cleanser correctly.

This way Execv keeps the old args, but Execve replaces them with new args, even if that's NULL.