### PR TITLE
Socketpair fix

### DIFF
--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -3155,7 +3155,7 @@ int32_t NaClSysSocketPair(struct NaClAppThread *natp,
   struct NaClApp          *nap = natp->nap;
   void                    *hd_struct = NULL;
   struct NaClHostDesc     *hd;
-  int                     lind_fd;
+  int                     lind_fds[2];
   int                     nacl_fd;
   int                     user_fd;
   int32_t                 retval;
@@ -3170,7 +3170,7 @@ int32_t NaClSysSocketPair(struct NaClAppThread *natp,
     return retval;
   }
 
-  retval = lind_socketpair (domain, type, protocol, fds, nap->cage_id);
+  retval = lind_socketpair (domain, type, protocol, lind_fds, nap->cage_id);
 
   if (retval < 0) {
     free(hd_struct);
@@ -3179,10 +3179,9 @@ int32_t NaClSysSocketPair(struct NaClAppThread *natp,
 
   for(int i=0; i<2; ++i) {
     hd = &((struct NaClHostDesc*)hd_struct)[i];
-    lind_fd = ((int*)fds)[i];
 
     //NaClHostDescCtor(hd, lind_fd, NACL_ABI_O_RDWR):
-    hd->d = lind_fd;
+    hd->d = lind_fds[i];
     hd->flags = NACL_ABI_O_RDWR;
 
     hd->cageid = nap->cage_id;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -3192,6 +3192,8 @@ int32_t NaClSysSocketPair(struct NaClAppThread *natp,
 
     /* copy out NaCl fds */
   if (!NaClCopyOutToUser(nap, (uintptr_t)fds, user_fds, sizeof(user_fds))) {
+      lind_close(lind_fds[0], nap->cage_id);
+      lind_close(lind_fds[1], nap->cage_id);
       retval = -NACL_ABI_EFAULT;
   }
 
@@ -4074,6 +4076,8 @@ int32_t NaClSysPipe(struct NaClAppThread  *natp, uint32_t *pipedes) {
 
   /* copy out NaCl fds */
   if (!NaClCopyOutToUser(nap, (uintptr_t)pipedes, nacl_fds, sizeof(nacl_fds))) {
+      lind_close(lind_fds[0], nap->cage_id);
+      lind_close(lind_fds[1], nap->cage_id);
       ret = -NACL_ABI_EFAULT;
   }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -3157,7 +3157,7 @@ int32_t NaClSysSocketPair(struct NaClAppThread *natp,
   struct NaClHostDesc     *hd;
   int                     lind_fds[2];
   int                     nacl_fd;
-  int                     user_fd;
+  int                     user_fds[2];
   int32_t                 retval;
 
   NaClLog(2, "Cage %d Entered NaClSysSocketPair(0x%08"NACL_PRIxPTR", "
@@ -3186,10 +3186,15 @@ int32_t NaClSysSocketPair(struct NaClAppThread *natp,
 
     hd->cageid = nap->cage_id;
     nacl_fd = NaClSetAvail(nap, ((struct NaClDesc *) NaClDescIoDescMake(hd)));
-    user_fd = NextFd(nap->cage_id);
-    fd_cage_table[nap->cage_id][user_fd] = nacl_fd;
-    fds[i] = user_fd;
+    user_fds[i] = NextFd(nap->cage_id);
+    fd_cage_table[nap->cage_id][user_fds[i]] = nacl_fd;
   }
+
+    /* copy out NaCl fds */
+  if (!NaClCopyOutToUser(nap, (uintptr_t)fds, user_fds, sizeof(user_fds))) {
+      retval = -NACL_ABI_EFAULT;
+  }
+
 
   NaClLog(2, "NaClSysSocketPair: returning %d\n", retval);
 


### PR DESCRIPTION
NaClSysSocketpair was sending a user address to RustPOSIX which is incorrect, and not using CopyOutToUser. This creates an array for the syscall and copies that out once it completes.

Please ignore that I named this branch socke**_r_**pair