### PR TITLE
CLOEXEC fixes

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -174,7 +174,8 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id, enum Na
     struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) &parent_nd->base;
     struct NaClHostDesc *parent_hd = self->hd;
 
-    if(parent_hd->flags & NACL_ABI_O_CLOEXEC) {
+    /* If we're creating an exec cage and we have CLOEXEC set, dont pass these on */
+    if ((tl_type == THREAD_LAUNCH_EXEC) && (parent_hd->flags & NACL_ABI_O_CLOEXEC)) {
       fd_cage_table[nap_child->cage_id][fd] = NACL_BAD_FD;
       continue;
     }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -485,7 +485,7 @@ int32_t NaClSysDup(struct NaClAppThread *natp, int oldfd) {
   }
 
   new_hd->d = lind_dup(old_hd->d, nap->cage_id);
-  new_hd->flags = old_hd->flags;
+  new_hd->flags = old_hd->flags  & ~NACL_ABI_O_CLOEXEC; // dup does not pass on CLOEXEC flag
   new_hd->cageid = nap->cage_id;
 
   /* Set new nacl desc as available */
@@ -566,7 +566,7 @@ int32_t NaClSysDup2(struct NaClAppThread  *natp,
     /* We have to use regular dup at this point because were creating a lind FD from scratch */
 
     new_hd->d = lind_dup(old_hd->d, nap->cage_id);
-    new_hd->flags = old_hd->flags;
+    new_hd->flags = old_hd->flags & ~NACL_ABI_O_CLOEXEC; // dup does not pass on CLOEXEC flag
     new_hd->cageid = nap->cage_id;
     new_hd->userfd = newfd;
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4041,6 +4041,7 @@ int32_t NaClSysPipe2(struct NaClAppThread  *natp, uint32_t *pipedes, int flags) 
       goto out;
     }
     hd->userfd = pipe_fd;
+    hd->flags = accflags | actualflags;
     fd_cage_table[nap->cage_id][pipe_fd] = retval;
     nacl_fds[i] = pipe_fd;
 
@@ -5230,7 +5231,11 @@ int32_t NaClSysFcntlSet (struct NaClAppThread *natp,
       struct NaClHostDesc *hostdesc;
       iodesc = (struct NaClDescIoDesc *) &ndp->base;
       hostdesc = iodesc->hd;
-      hostdesc->flags |= ~(set_op & NACL_ABI_O_CLOEXEC);
+      if(set_op & NACL_ABI_O_CLOEXEC) {
+        hostdesc->flags |= NACL_ABI_O_CLOEXEC;
+      } else {
+        hostdesc->flags &= ~NACL_ABI_O_CLOEXEC;
+      }
     }
 
     ret = lind_fcntl_set(fdtrans, cmd, set_op, nap->cage_id);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -5230,7 +5230,7 @@ int32_t NaClSysFcntlSet (struct NaClAppThread *natp,
       struct NaClHostDesc *hostdesc;
       iodesc = (struct NaClDescIoDesc *) &ndp->base;
       hostdesc = iodesc->hd;
-      hostdesc->flags |= ~(set_op & NACL_ABI_O_CLOEXEC);
+      hostdesc->flags &= ~(set_op & NACL_ABI_O_CLOEXEC);
     }
 
     ret = lind_fcntl_set(fdtrans, cmd, set_op, nap->cage_id);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -592,7 +592,7 @@ int32_t NaClSysDup2(struct NaClAppThread  *natp,
     struct NaClHostDesc *new_hd = new_self->hd;
 
     new_hd->d = lind_dup2(old_hd->d, new_hd->d, nap->cage_id);
-    new_hd->flags = old_hd->flags;
+    new_hd->flags = old_hd->flags  & ~NACL_ABI_O_CLOEXEC; // dup does not pass on CLOEXEC flag
     new_hd->cageid = nap->cage_id;
 
     /* Re-add the nacl desc to the nap */


### PR DESCRIPTION
PR from @jesings and I that fixes a few errors with CLOEXEC
- now doesn't pass flags in dup/dup2
- only closes on exec and not fork
- fixes fcntlset for cloexec