### PR TITLE
Socket deadlock, Accept fix, Select fix

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -199,7 +199,7 @@ int lind_recvfrom (int sockfd, const void *buf, size_t len, int flags, struct so
 }
 
 int lind_accept(int sockfd, struct sockaddr *sockaddr, socklen_t *addrlen, int cageid) {
-    DISPATCH_SYSCALL_3(LIND_safe_net_accept, int, sockfd, sockaddrstruct, sockaddr, socklen_t_ptr, addrlen);
+    DISPATCH_SYSCALL_3_inner(LIND_safe_net_accept, int, sockfd, sockaddrstruct, sockaddr, socklen_t_ptr, addrlen, 0);
 }
 
 int lind_connect (int sockfd, const struct sockaddr *src_addr, socklen_t addrlen, int cageid) {

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -199,8 +199,7 @@ int lind_recvfrom (int sockfd, const void *buf, size_t len, int flags, struct so
 }
 
 int lind_accept(int sockfd, struct sockaddr *sockaddr, socklen_t *addrlen, int cageid) {
-    BLANKARGS;
-    DISPATCH_SYSCALL_3_inner(LIND_safe_net_accept, int, sockfd, sockaddrstruct, sockaddr, socklen_t_ptr, addrlen, 0);
+    DISPATCH_SYSCALL_3(LIND_safe_net_accept, int, sockfd, sockaddrstruct, sockaddr, socklen_t_ptr, addrlen);
 }
 
 int lind_connect (int sockfd, const struct sockaddr *src_addr, socklen_t addrlen, int cageid) {

--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -199,6 +199,7 @@ int lind_recvfrom (int sockfd, const void *buf, size_t len, int flags, struct so
 }
 
 int lind_accept(int sockfd, struct sockaddr *sockaddr, socklen_t *addrlen, int cageid) {
+    BLANKARGS;
     DISPATCH_SYSCALL_3_inner(LIND_safe_net_accept, int, sockfd, sockaddrstruct, sockaddr, socklen_t_ptr, addrlen, 0);
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -5216,7 +5216,6 @@ int32_t NaClSysAccept(struct NaClAppThread *natp,
   ndp = GetDescFromCagetable(nap, sockfd);
   if (!ndp) {
     NaClLog(2, "NaClSysAccept was passed an unrecognized file descriptor, returning %d\n", sockfd);
-    free(nd);
     return -NACL_ABI_EBADF;
   }
   
@@ -5225,7 +5224,6 @@ int32_t NaClSysAccept(struct NaClAppThread *natp,
  
   if ((void*) kNaClBadAddress == syslenaddr) {
     NaClLog(2, "NaClSysAccept could not translate buffer address, returning %d\n", -NACL_ABI_EFAULT);
-    free(nd);
     userfd = -NACL_ABI_EFAULT; // As we return userfd instead of a retvalue, changed ret with userfd.
     goto cleanup;
   }
@@ -5235,14 +5233,12 @@ int32_t NaClSysAccept(struct NaClAppThread *natp,
  
     if ((void*) kNaClBadAddress == sysvaladdr) {
       NaClLog(2, "NaClSysAccept could not translate buffer address, returning %d\n", -NACL_ABI_EFAULT);
-      free(nd);
       userfd = -NACL_ABI_EFAULT; // As we return userfd instead of a retvalue, changed ret with userfd.
       goto cleanup;
     }
   } else {
     if(addr != NULL) {
       NaClLog(2, "NaClSysAccept had a 0 length specified but the address was not NULL, returning %d\n", -NACL_ABI_EINVAL);
-      free(nd);
       userfd = -NACL_ABI_EINVAL;
       goto cleanup;
     } else {

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -5213,12 +5213,6 @@ int32_t NaClSysAccept(struct NaClAppThread *natp,
   NaClLog(2, "Cage %d Entered NaClSysAccept(0x%08"NACL_PRIxPTR", %d, 0x%08"NACL_PRIxPTR", 0x%08"NACL_PRIxPTR")\n",
           nap->cage_id, (uintptr_t) natp, sockfd, (uintptr_t) addr, (uintptr_t) addrlen);
 
-  nd = malloc(sizeof(struct NaClHostDesc));
-  if (!nd) {
-    NaClLog(2, "NaClSysAccept could not allocate room for returning NaCl desc\n");
-    return -NACL_ABI_ENOMEM;
-  }
-
   ndp = GetDescFromCagetable(nap, sockfd);
   if (!ndp) {
     NaClLog(2, "NaClSysAccept was passed an unrecognized file descriptor, returning %d\n", sockfd);
@@ -5257,6 +5251,14 @@ int32_t NaClSysAccept(struct NaClAppThread *natp,
   }
 
   ret = lind_accept(sockfd, sysvaladdr, syslenaddr, nap->cage_id);
+  if (ret < 0) goto cleanup;
+
+
+  nd = malloc(sizeof(struct NaClHostDesc));
+  if (!nd) {
+    NaClLog(2, "NaClSysAccept could not allocate room for returning NaCl desc\n");
+    return -NACL_ABI_ENOMEM;
+  }
 
   nd->d = ret;
   nd->flags = NACL_ABI_O_RDWR;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -5657,7 +5657,7 @@ char *fd_set_fd_translator_tolind(struct NaClApp* nap, fd_set *fdset, int maxfd,
     }
   }
 
-  char *newset = malloc((ourmax + 7) / 8); //bitfield which can contain our fds now
+  char *newset = calloc((ourmax + 7) / 8, sizeof(char)); //bitfield which can contain our fds now
   if(!newset)
     return (char*) -NACL_ABI_ENOMEM;
   for(int i = 0; i < fdsindex; i++) {

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -947,9 +947,9 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
 
 
 
-  NaClHostDescCheckValidity("NaClHostDescRead", hd);
-  if (NACL_ABI_O_WRONLY == (d->flags & NACL_ABI_O_ACCMODE)) {
-    NaClLog(3, "NaClHostDescRead: WRONLY file\n");
+  NaClHostDescCheckValidity("NaClSysRead", hd);
+  if (NACL_ABI_O_WRONLY == (hd->flags & NACL_ABI_O_ACCMODE)) {
+    NaClLog(3, "NaClSysRead: WRONLY file\n");
     retval = -NACL_ABI_EBADF;
     goto out;
   }
@@ -1129,9 +1129,9 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) &ndp->base;
   struct NaClHostDesc *hd = self->hd;
 
-  NaClHostDescCheckValidity("NaClHostDescWrite", hd);
-  if (NACL_ABI_O_RDONLY == (d->flags & NACL_ABI_O_ACCMODE)) {
-    NaClLog(3, "NaClHostDescWrite: RDONLY file\n");
+  NaClHostDescCheckValidity("NaClSysWrite", hd);
+  if (NACL_ABI_O_RDONLY == (hd->flags & NACL_ABI_O_ACCMODE)) {
+    NaClLog(3, "NaClSysWrite: RDONLY file\n");
     retval = -NACL_ABI_EBADF;
     goto out;
   }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -939,6 +939,7 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   NaClFastMutexLock(&nap->desc_mu);
   /* It's fine to not do a ref here because the mutex will assure that a close() can't be called in between */
   ndp = NaClGetDescMuNoRef(nap, fd);
+  NaClFastMutexUnlock(&nap->desc_mu);
 
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
   if (!ndp) {
@@ -987,7 +988,6 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t) read_result;
 out:
-  NaClFastMutexUnlock(&nap->desc_mu);
   return retval;
 }
 
@@ -1108,6 +1108,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   NaClFastMutexLock(&nap->desc_mu);
   /* It's fine to not do a ref here because the mutex will assure that a close() can't be called in between */
   ndp = NaClGetDescMuNoRef(nap, fd);
+  NaClFastMutexUnlock(&nap->desc_mu);
 
 
   NaClLog(2, " ndp = %"NACL_PRIxPTR"\n", (uintptr_t) ndp);
@@ -1151,7 +1152,6 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   retval = (int32_t)write_result;
 
 out:
-  NaClFastMutexUnlock(&nap->desc_mu);
   return retval;
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -5251,7 +5251,10 @@ int32_t NaClSysAccept(struct NaClAppThread *natp,
   }
 
   ret = lind_accept(sockfd, sysvaladdr, syslenaddr, nap->cage_id);
-  if (ret < 0) goto cleanup;
+  if (ret < 0) {
+    userfd = ret;
+    goto cleanup;
+  }
 
 
   nd = malloc(sizeof(struct NaClHostDesc));


### PR DESCRIPTION
This PR fixes:

1. A deadlock issue on I/O calls to read and write when writing to sockets
2. Properly creates an accept nacl desc when accept succeeds
3. Small fix for select that uses calloc instead of malloc for the bitfield