### PR TITLE
Fix HostDesc functions so errno falls through to glibc

### DIFF
--- a/src/shared/platform/posix/nacl_host_desc.c
+++ b/src/shared/platform/posix/nacl_host_desc.c
@@ -326,9 +326,9 @@ int NaClHostDescOpen(struct NaClHostDesc  *d,
           path, posix_flags, mode);
   host_desc = lind_open(path, posix_flags, mode, d->cageid);
   NaClLog(3, "NaClHostDescOpen: got descriptor %d\n", host_desc);
-  if (-1 == host_desc) {
-    NaClLog(2, "NaClHostDescOpen: open returned -1, errno %d\n", errno);
-    return -NaClXlateErrno(errno);
+  if (host_desc < 0) {
+    NaClLog(2, "NaClHostDescOpen: open returned -1, errno %d\n", host_desc);
+    return host_desc;
   }
  
   return NaClHostDescCtor(d, host_desc, flags);
@@ -410,8 +410,7 @@ ssize_t NaClHostDescRead(struct NaClHostDesc  *d,
     NaClLog(3, "NaClHostDescRead: WRONLY file\n");
     return -NACL_ABI_EBADF;
   }
-  return ((-1 == (retval = lind_read(d->d, buf, len, d->cageid)))
-          ? -NaClXlateErrno(errno) : retval);
+  return lind_read(d->d, buf, len, d->cageid);
 }
 
 ssize_t NaClHostDescWrite(struct NaClHostDesc *d,
@@ -424,8 +423,7 @@ ssize_t NaClHostDescWrite(struct NaClHostDesc *d,
     NaClLog(3, "NaClHostDescWrite: RDONLY file\n");
     return -NACL_ABI_EBADF;
   }
-  return ((-1 == (retval = lind_write(d->d, buf, len, d->cageid)))
-          ? -NaClXlateErrno(errno) : retval);
+  return lind_write(d->d, buf, len, d->cageid);
 }
 
 nacl_off64_t NaClHostDescSeek(struct NaClHostDesc  *d,
@@ -435,8 +433,7 @@ nacl_off64_t NaClHostDescSeek(struct NaClHostDesc  *d,
 
   NaClHostDescCheckValidity("NaClHostDescSeek", d);
 #if NACL_LINUX
-  return ((-1 == (retval = lind_lseek(d->d, offset, whence, d->cageid)))
-          ? -NaClXlateErrno(errno) : retval);
+  return lind_lseek(d->d, offset, whence, d->cageid);
 #elif NACL_OSX
   return ((-1 == (retval = lind_lseek(d->d, offset, whence, d->cageid)))
           ? -NaClXlateErrno(errno) : retval);
@@ -456,8 +453,7 @@ ssize_t NaClHostDescPRead(struct NaClHostDesc *d,
     NaClLog(3, "NaClHostDescPRead: WRONLY file\n");
     return -NACL_ABI_EBADF;
   }
-  return ((-1 == (retval = lind_pread(d->d, buf, len, offset, d->cageid)))
-          ? -NaClXlateErrno(errno) : retval);
+  return lind_pread(d->d, buf, len, offset, d->cageid);
 }
 
 ssize_t NaClHostDescPWrite(struct NaClHostDesc *d,
@@ -482,11 +478,9 @@ ssize_t NaClHostDescPWrite(struct NaClHostDesc *d,
    * seek-to-end-before-write semantics apply.
    */
   if (0 != (d->flags & NACL_ABI_O_APPEND)) {
-    return ((-1 == (retval = lind_write(d->d, buf, len, d->cageid)))
-            ? -NaClXlateErrno(errno) : retval);
+    return lind_write(d->d, buf, len, d->cageid);
   }
-  return ((-1 == (retval = lind_pwrite(d->d, buf, len, offset, d->cageid)))
-          ? -NaClXlateErrno(errno) : retval);
+  return lind_pwrite(d->d, buf, len, offset, d->cageid);
 }
 
 
@@ -507,9 +501,7 @@ int NaClHostDescFstat(struct NaClHostDesc  *d,
                       nacl_host_stat_t     *nhsp) {
   NaClHostDescCheckValidity("NaClHostDescFstat", d);
 #if NACL_LINUX
-  if (lind_fxstat(d->d, nhsp, d->cageid) == -1) {
-    return -errno;
-  }
+  return lind_fxstat(d->d, nhsp, d->cageid);
 #elif NACL_OSX
   if (lind_fxstat(d->d, nhsp, d->cageid) == -1) {
     return -errno;
@@ -526,10 +518,10 @@ int NaClHostDescClose(struct NaClHostDesc *d) {
 
   NaClHostDescCheckValidity("NaClHostDescClose", d);
   retval = lind_close(d->d, d->cageid);
-  if (-1 != retval) {
+  if (retval > 0) {
     d->d = -1;
   }
-  return (-1 == retval) ? -NaClXlateErrno(errno) : retval;
+  return retval;
 }
 
 /*
@@ -541,9 +533,7 @@ int NaClHostDescStat(char const       *host_os_pathname,
 		     int cageid) {
 
 #if NACL_LINUX
-  if (lind_xstat(host_os_pathname, nhsp, cageid) == -1) {
-    return -errno;
-  }
+  return lind_xstat(host_os_pathname, nhsp, cageid);
 #elif NACL_OSX
   if (lind_xstat(host_os_pathname, nhsp, cageid) == -1) {
     return -errno;

--- a/src/shared/platform/posix/nacl_host_desc.c
+++ b/src/shared/platform/posix/nacl_host_desc.c
@@ -327,7 +327,7 @@ int NaClHostDescOpen(struct NaClHostDesc  *d,
   host_desc = lind_open(path, posix_flags, mode, d->cageid);
   NaClLog(3, "NaClHostDescOpen: got descriptor %d\n", host_desc);
   if (host_desc < 0) {
-    NaClLog(2, "NaClHostDescOpen: open returned -1, errno %d\n", host_desc);
+    NaClLog(2, "NaClHostDescOpen: open returned errno: %d\n", host_desc);
     return host_desc;
   }
  

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -769,7 +769,7 @@ int32_t NaClSysOpen(struct NaClAppThread  *natp,
   
   if (retval < 0) {
     NaClLog(1, "Open returned error %d\n", retval);
-    return -NACL_ABI_EPERM;
+    return retval;
   }
   
   fd_retval = NaClSetAvail(nap, ((struct NaClDesc *) NaClDescIoDescMake(hd)));


### PR DESCRIPTION
These functions were checking if -1 was returned from the old dispatcher format, now they return the negative retval.