### PR TITLE
libc 2.34 fixes

### DIFF
--- a/src/shared/platform/posix/nacl_threads.c
+++ b/src/shared/platform/posix/nacl_threads.c
@@ -7,6 +7,7 @@
 /*
  * NaCl Server Runtime threads implementation layer.
  */
+#undef _GNU_SOURCE
 
 #include <string.h>
 #include <stdlib.h>
@@ -19,7 +20,6 @@
 #include <sys/types.h>
 #include <signal.h>
 
-#undef _GNU_SOURCE
 #include <pthread.h>
 #include <limits.h>
 /*

--- a/src/shared/platform/posix/nacl_threads.c
+++ b/src/shared/platform/posix/nacl_threads.c
@@ -18,6 +18,8 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <signal.h>
+
+#undef _GNU_SOURCE
 #include <pthread.h>
 #include <limits.h>
 /*
@@ -141,3 +143,4 @@ void NaClThreadCancel(struct NaClThread *ntp) {
   pthread_cancel(ntp->tid);
 }
 
+#define _GNU_SOURCE

--- a/src/shared/platform/posix/nacl_threads.c
+++ b/src/shared/platform/posix/nacl_threads.c
@@ -19,7 +19,6 @@
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <signal.h>
-
 #include <pthread.h>
 #include <limits.h>
 /*

--- a/src/trusted/service_runtime/posix/nacl_signal_stack.c
+++ b/src/trusted/service_runtime/posix/nacl_signal_stack.c
@@ -4,6 +4,8 @@
  * found in the LICENSE file.
  */
 
+#undef _GNU_SOURCE
+
 #include <errno.h>
 #include <signal.h>
 #include <string.h>
@@ -112,3 +114,5 @@ void NaClSignalStackUnregister(void) {
             strerror(errno));
   }
 }
+
+#define _GNU_SOURCE

--- a/tests/thread_capture/nacl_thread_capture_test_injection_test.c
+++ b/tests/thread_capture/nacl_thread_capture_test_injection_test.c
@@ -78,8 +78,8 @@ void NaClSignalHandler(int signum, siginfo_t *info, void *other) {
   CHECK(g_nacl_syscall_thread_capture_fault_addr == faulting_pc);
   exit(0);
 }
-
-static char g_nacl_altstack[SIGSTKSZ + 4096];
+#define LINUX_SIGSTKSZ 8192
+static char g_nacl_altstack[LINUX_SIGSTKSZ + 4096];
 
 void NaClSetSignalHandler(void) {
   struct sigaction action;

--- a/tests/thread_capture/nacl_thread_capture_test_injection_test.c
+++ b/tests/thread_capture/nacl_thread_capture_test_injection_test.c
@@ -78,7 +78,7 @@ void NaClSignalHandler(int signum, siginfo_t *info, void *other) {
   CHECK(g_nacl_syscall_thread_capture_fault_addr == faulting_pc);
   exit(0);
 }
-#define LINUX_SIGSTKSZ 8192
+#define LINUX_SIGSTKSZ 8192 // as of libc 2.34 SIGSTKSZ is no longer a constant, we define it to the old linux value for the purposes of this test
 static char g_nacl_altstack[LINUX_SIGSTKSZ + 4096];
 
 void NaClSetSignalHandler(void) {


### PR DESCRIPTION
Some minor fixes so that we can compile with native libc > 2.34 which us allows us to update to newer tools in our containers (perf, RR, etc...)

These revolve around libc changing how the macros work for PTHREAD_STACK_MIN and SIGSTKSZ (https://lists.gnu.org/archive/html/info-gnu/2021-08/msg00001.html). We can get around this by undefining `_GNU_SOURCE` in the nacl threads and signal stack files. We also have to manually define the SIGSTKSZ value in one of the nacl tests because of a dependency knot with signal and ucontext macros, but this is not really a big deal.