### PR TITLE
Zombies

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -797,6 +797,7 @@ void NaClAppThreadDelete(struct NaClAppThread *natp) {
   NaClAlignedFree(natp);
 }
 
+
 /**
  * The following functions are used to reap any cages which have received a fatal signal.
  * On launch, sel_main creates the Reaper thread which calls the fault teardown functions when

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -797,7 +797,6 @@ void NaClAppThreadDelete(struct NaClAppThread *natp) {
   NaClAlignedFree(natp);
 }
 
-
 /**
  * The following functions are used to reap any cages which have received a fatal signal.
  * On launch, sel_main creates the Reaper thread which calls the fault teardown functions when

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4970,7 +4970,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
 
   // First check if we have children, if not check zombies, if no zombies return ECHILD
   if (!nap->num_children || pid > pid_max) {
-    struct NaClZombie* zombie = NaClWaitZombies(nap);
+    struct NaClZombie* zombie = NaClCheckZombies(nap);
     if (zombie == NULL) ret = -NACL_ABI_ECHILD;
     else {
       ret = zombie->cage_id;
@@ -5035,7 +5035,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
             if (nap_child) *stat_loc_ptr = nap_child->exit_status;
             else {
               // this could be a zombie so lets check in this case
-              struct NaClZombie* zombie = NaClWaitZombies(nap);
+              struct NaClZombie* zombie = NaClCheckZombies(nap);
               *stat_loc_ptr = zombie->exit_status;
             }
             NaClRemoveZombie(nap, cage_id); //remove from zombie list regardless

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4969,7 +4969,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   }
 
   if (!nap->num_children || pid > pid_max) {
-    struct NaClZombie* zombie = NaClWaitZombies(stat_loc_ptr);
+    struct NaClZombie* zombie = NaClWaitZombies(nap);
     if (zombie == NULL) ret = -NACL_ABI_ECHILD;
     else {
       ret = zombie->cage_id;
@@ -5000,7 +5000,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     }
     NaClXCondVarBroadcast(&nap->children_cv);
     NaClXMutexUnlock(&nap->children_mu);
-    RemoveZombie(nap, pid);
+    NaClRemoveZombie(nap, pid);
 
     ret = pid;
     *stat_loc_ptr = nap_child->exit_status;
@@ -5036,7 +5036,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
             ret = cage_id;
             NaClXCondVarBroadcast(&nap->children_cv);
             NaClXMutexUnlock(&nap->children_mu);
-            RemoveZombie(nap, cage_id);
+            NaClRemoveZombie(nap, cage_id);
             *stat_loc_ptr = nap_child->exit_status;
             goto out;
           }

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4974,8 +4974,8 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     else {
       ret = zombie->cage_id;
       *stat_loc_ptr = zombie->exit_status;
+       NaClRemoveZombie(nap, zombie->cage_id);
     }
-    NaClRemoveZombie(nap, zombie->cage_id);
     goto out;
   }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -5036,8 +5036,12 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
             ret = cage_id;
             NaClXCondVarBroadcast(&nap->children_cv);
             NaClXMutexUnlock(&nap->children_mu);
+            if (nap_child) *stat_loc_ptr = nap_child->exit_status;
+            else {
+              struct NaClZombie* zombie = NaClWaitZombies(nap);
+              *stat_loc_ptr = zombie->exit_status;
+            }
             NaClRemoveZombie(nap, cage_id);
-            *stat_loc_ptr = nap_child->exit_status;
             goto out;
           }
         }

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1947,11 +1947,11 @@ struct NaClZombie* NaClWaitZombies(struct NaClApp *nap) {
   struct NaClZombie* zombie = NULL;
   for(int cage_id = 0; cage_id < nap->children.num_entries; cage_id++) {
     zombie = DynArrayGet(&nap->zombies, cage_id);
-    if (zombie != NULL) return zombie;
+    if (zombie != NULL) break;
   }
   NaClMutexUnlock(&nap->zombie_mu);
 
-  return NULL;
+  return zombie;
 }
 
 void NaClRemoveZombie(struct NaClApp *nap, int cage_id) {

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -401,6 +401,7 @@ void NaClAppDtor(struct NaClApp *nap) {
 
   NaClLog(3, "Tearing down dyn arrays\n");
   DynArrayDtor(&nap->children);
+  DynArrayDtor(&nap->zombies);
   DynArrayDtor(&nap->desc_tbl);
   DynArrayDtor(&nap->threads);
   free(nap->cpu_features);

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1955,11 +1955,11 @@ struct NaClZombie* NaClWaitZombies(struct NaClApp *nap) {
 }
 
 void NaClRemoveZombie(struct NaClApp *nap, int cage_id) {
-  NaClMutexLock(&nap->children_mu);
+  NaClMutexLock(&nap->zombie_mu);
   struct NaClZombie* zombie = DynArrayGet(&nap->zombies, cage_id);
   DynArraySet(&nap->zombies, cage_id, NULL);
   free(zombie);
-  NaClMutexUnlock(&nap->children_mu);
+  NaClMutexUnlock(&nap->zombie_mu);
 }
 
 void NaClAddZombie(struct NaClApp *nap) {

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -68,15 +68,8 @@ double time_counter = 0.0;
 double time_start = 0.0;
 double time_end = 0.0;
 
-/*
- * `fd_cage_table[cage_id][fd] = real fd`
- *
- * The [fd] idx is the virtual fd visible to the cages.
- *
- * -jp
- */
 volatile sig_atomic_t fork_num;
-int fd_cage_table[CAGE_MAX][FILE_DESC_MAX];
+int fd_cage_table[CAGE_MAX][FILE_DESC_MAX]; // fd_cage_table[cage_id][userfd] = nacl fd/desc idx
 struct NaClShmInfo shmtable[FILE_DESC_MAX];
 
 static int IsEnvironmentVariableSet(char const *env_name) {

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1942,6 +1942,12 @@ int AllocNextFdBounded(struct NaClApp *nap, int lowerbound, struct NaClHostDesc 
   return userfd;
 }
 
+/*
+ * Zombie functions.
+ * Will add any exiting child process to zombie list.
+ * Zombies removed via wait will be removed from list
+ */
+
 struct NaClZombie* NaClWaitZombies(struct NaClApp *nap) {
   NaClMutexLock(&nap->zombie_mu);
   struct NaClZombie* zombie = NULL;

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -143,6 +143,7 @@ struct NaClApp {
   struct NaClCondVar        children_cv;
   struct DynArray           children;
   struct DynArray           zombies;
+  struct NaClMutex          zombie_mu;
   struct NaClApp            *parent;
 
   volatile sig_atomic_t     num_children;

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -958,7 +958,7 @@ int CancelFds(struct NaClApp *nap, int userfds[2], int iterations);
 int AllocNextFd(struct NaClApp *nap, struct NaClHostDesc *hd);
 int AllocNextFdBounded(struct NaClApp *nap, int lowerbound, struct NaClHostDesc *hd);
 
-struct NaClZombie* NaClWaitZombies(struct NaClApp *nap);
+struct NaClZombie* NaClCheckZombies(struct NaClApp *nap);
 void NaClRemoveZombie(struct NaClApp *nap, int cage_id);
 void NaClAddZombie(struct NaClApp *nap);
 

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -94,7 +94,7 @@ struct NaClShmInfo {
 struct NaClZombie {
   int cage_id;
   int exit_status;
-}
+};
 
 extern volatile sig_atomic_t fork_num;
 extern int fd_cage_table[CAGE_MAX][FILE_DESC_MAX];

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -91,6 +91,11 @@ struct NaClShmInfo {
   bool rmid;
 };
 
+struct NaClZombie {
+  int cage_id;
+  int exit_status;
+}
+
 extern volatile sig_atomic_t fork_num;
 extern int fd_cage_table[CAGE_MAX][FILE_DESC_MAX];
 extern struct NaClShmInfo shmtable[FILE_DESC_MAX];
@@ -137,6 +142,7 @@ struct NaClApp {
   struct NaClMutex          children_mu;
   struct NaClCondVar        children_cv;
   struct DynArray           children;
+  struct DynArray           zombies;
   struct NaClApp            *parent;
 
   volatile sig_atomic_t     num_children;
@@ -950,6 +956,10 @@ void InitializeCage(struct NaClApp *nap, int cage_id);
 int CancelFds(struct NaClApp *nap, int userfds[2], int iterations);
 int AllocNextFd(struct NaClApp *nap, struct NaClHostDesc *hd);
 int AllocNextFdBounded(struct NaClApp *nap, int lowerbound, struct NaClHostDesc *hd);
+
+struct NaClZombie* NaClWaitZombies(struct NaClApp *nap);
+void NaClRemoveZombie(struct NaClApp *nap, int cage_id);
+void NaClAddZombie(struct NaClApp *nap);
 
 static INLINE void NaClLogUserMemoryContent(struct NaClApp *nap, uintptr_t user_addr) {
   char *addr = (char *)NaClUserToSys(nap, user_addr);

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -646,7 +646,7 @@ int NaClReportExitStatus(struct NaClApp *nap, int exit_status) {
      */
   }
   nap->exit_status = exit_status;
-  NaClAddZombie(nap);
+  if (nap->parent) NaClAddZombie(nap);
   nap->running = 0;
   NaClXCondVarSignal(&nap->cv);
 

--- a/src/trusted/service_runtime/sel_ldr_standard.c
+++ b/src/trusted/service_runtime/sel_ldr_standard.c
@@ -646,6 +646,7 @@ int NaClReportExitStatus(struct NaClApp *nap, int exit_status) {
      */
   }
   nap->exit_status = exit_status;
+  NaClAddZombie(nap);
   nap->running = 0;
   NaClXCondVarSignal(&nap->cv);
 


### PR DESCRIPTION
Adds a zombie list for all processes to hold exited children. Removes zombies when waited on.

Generally fixes up comments for waitpid() as well.