### PR TITLE
Concurrency fixes

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -154,7 +154,7 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id, enum Na
   }
   
   /* duplicate file descriptor table starting at child_fd = 3 (0-2 setup previously)*/
-  for (int fd = 0; fd <= FILE_DESC_MAX; fd++) {
+  for (int fd = 0; fd < FILE_DESC_MAX; fd++) {
 
     /* Retrive the host fd we had stored in the Cage Table for the parent */
     int parent_host_fd = fd_cage_table[nap_parent->cage_id][fd];

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -934,7 +934,9 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   NaClFastMutexLock(&nap->desc_mu);
   /* It's fine to not do a ref here because the mutex will assure that a close() can't be called in between */
   ndp = NaClGetDescMuNoRef(nap, fd);
-
+  if (!ndp) {
+    return - NACL_ABI_EBADF;
+  }
   /* Translate from NaCl Desc to Host Desc */
   struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) &ndp->base;
   struct NaClHostDesc *hd = self->hd;
@@ -1120,7 +1122,9 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   NaClFastMutexLock(&nap->desc_mu);
   /* It's fine to not do a ref here because the mutex will assure that a close() can't be called in between */
   ndp = NaClGetDescMuNoRef(nap, fd);
-
+  if (!ndp) {
+    return - NACL_ABI_EBADF;
+  }
    /* Translate from NaCl Desc to Host Desc */
   struct NaClDescIoDesc *self = (struct NaClDescIoDesc *) &ndp->base;
   struct NaClHostDesc *hd = self->hd;

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -870,6 +870,8 @@ int NaClSelLdrMain(int argc, char **argv) {
   }
 
   NACL_TEST_INJECTION(BeforeMainThreadLaunches, ());
+  if ((argv + optind)[3] == NULL) NaClLog(LOG_FATAL, "%s\n", "FATAL: You must specify a binary.");
+
   NaClLog(1, "[NaCl Main][Cage 1] argv[3]: %s \n\n", (argv + optind)[3]);
   NaClLog(1, "[NaCl Main][Cage 1] argv[4]: %s \n\n", (argv + optind)[4]);
   NaClLog(1, "[NaCl Main][Cage 1] argv num: %d \n\n", argc - optind);


### PR DESCRIPTION
A few fixes to NaCl.

- Fixes the scenario where Lind isn't supplied an initial nexe file
- Fixes off by one error in desc copying for cage ctor
- properly checks for NDP in read/write and releases mutex