### PR TITLE
Waitpid Overhaul

### DIFF
--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4878,6 +4878,12 @@ fail:
 #define WAIT_ANY (-1)
 #define WAIT_ANY_PG 0
 
+/*
+ * Wait/Waitpid is used to reap a process's exited children, referred to as zombies
+ * We use the NaClCheckZombies/NaClAddZombies/NaClRemoveZombies functions from sel_ldr.c to manage these zombies
+ * Zombies are added to a parents zombie list when a child exits, in the NaClReportExitStatus function in sel_ldr_standard.c
+ */
+
 int32_t NaClSysWaitpid(struct NaClAppThread *natp,
                        int pid,
                        uint32_t *stat_loc,
@@ -4956,7 +4962,6 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       NaClXCondVarTimedWaitRelative(&nap->children_cv, &nap->children_mu, &timeout);
 
       // check the zombies dynarray, and lazily return the first exited process if it exists
-
       struct NaClZombie* zombie = NaClCheckZombies(nap);
       if (zombie) {
         if (stat_loc_ptr) *stat_loc_ptr = zombie->exit_status; // set the status pointer if it exists

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4905,7 +4905,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     if (zombie == NULL) ret = -NACL_ABI_ECHILD;
     else {
       ret = zombie->cage_id;
-      *stat_loc_ptr = zombie->exit_status;
+        if (stat_loc_ptr) *stat_loc_ptr = zombie->exit_status;
        NaClRemoveZombie(nap, zombie->cage_id);
     }
     goto out;
@@ -4933,7 +4933,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     NaClRemoveZombie(nap, pid);
 
     ret = pid;
-    *stat_loc_ptr = nap_child->exit_status;
+    if (stat_loc_ptr) *stat_loc_ptr = nap_child->exit_status;
     goto out;
   }
 
@@ -4954,7 +4954,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
 
       struct NaClZombie* zombie = NaClCheckZombies(nap);
       if (zombie) {
-        *stat_loc_ptr = zombie->exit_status;
+        if (stat_loc_ptr) *stat_loc_ptr = zombie->exit_status;
         ret = zombie->cage_id;
         NaClRemoveZombie(nap, ret); //remove from zombie list regardless
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4924,7 +4924,6 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       goto out;
     }
     NaClLog(1, "Thread children count: %d\n", nap->num_children);
-    NaClXMutexUnlock(&nap->children_mu);
 
     /* wait for child to finish */
     while (!zombie) {
@@ -4933,6 +4932,8 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     }
 
     NaClXCondVarBroadcast(&nap->children_cv);
+    NaClXMutexUnlock(&nap->children_mu);
+
     if (stat_loc_ptr) *stat_loc_ptr = zombie->exit_status;
     ret = zombie->cage_id;
     NaClRemoveZombie(nap, zombie->cage_id);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4950,8 +4950,6 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       /* make sure children exist, if not send ABI_ECHILD */
       if (!nap->num_children && !nap->zombies.num_entries) {
         ret = -NACL_ABI_ECHILD;
-        NaClXCondVarBroadcast(&nap->children_cv);
-        NaClXMutexUnlock(&nap->children_mu);
         goto out;
       }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4942,13 +4942,12 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
     while(1){
 
       /* make sure children exist, if not send ABI_ECHILD */
-      if (!nap->num_children) {
+      if (!nap->num_children && !nap->zombies.num_entries) {
         ret = -NACL_ABI_ECHILD;
         NaClXCondVarBroadcast(&nap->children_cv);
         NaClXMutexUnlock(&nap->children_mu);
         goto out;
       }
-
 
       NaClXMutexLock(&nap->children_mu);
       NaClXCondVarTimedWaitRelative(&nap->children_cv, &nap->children_mu, &timeout);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4986,11 +4986,6 @@ int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc) {
   int ret;
 
   NaClLog(1, "%s\n", "[NaClSysWait] entered wait! \n");
-
-  if (!nap->num_children) {
-    ret = -NACL_ABI_ECHILD;
-    goto out;
-  }
   ret = NaClSysWaitpid(natp, WAIT_ANY, stat_loc, 0);
 
 out:

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4987,7 +4987,6 @@ out:
 }
 
 int32_t NaClSysWait(struct NaClAppThread *natp, uint32_t *stat_loc) {
-  struct NaClApp *nap = natp->nap;
   int ret;
 
   NaClLog(1, "%s\n", "[NaClSysWait] entered wait! \n");

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4953,6 +4953,8 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       /* make sure children exist, if not send ABI_ECHILD */
       if (!nap->num_children && !nap->zombies.num_entries) {
         ret = -NACL_ABI_ECHILD;
+        NaClXCondVarBroadcast(&nap->children_cv);
+        NaClXMutexUnlock(&nap->children_mu);
         goto out;
       }
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4931,7 +4931,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       NaClXCondVarTimedWaitRelative(&nap->children_cv, &nap->children_mu, &timeout);
       zombie = NaClCheckZombies(nap); //re-check on signal
     }
-    
+
   } else {
     // else we have an explicit waitpid with child pid given, lets wait for that pid
 
@@ -4959,7 +4959,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   NaClRemoveZombie(nap, zombie->cage_id);
 
 out:
-  NaClXCondVarBroadcast(&nap->children_cv);
+  // NaClXCondVarBroadcast(&nap->children_cv);
   NaClXMutexUnlock(&nap->children_mu);
 
   NaClLog(1, "[NaClSysWaitpid] pid = %d \n", pid);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4917,7 +4917,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
 
     // check the zombies dynarray, and lazily return the first exited process if it exists
     zombie = NaClCheckZombies(nap);
-    if (!zombie && (options & WNOHANG)) goto out; // exit here if WNOHANG
+    if (!zombie && (options & WNOHANG)) goto out; // exit here if WNOHANG, ret stays initialized to 0
     while(!zombie){
 
       /* make sure children exist, if not send ABI_ECHILD */
@@ -4934,7 +4934,7 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
 
   } else {   // else we have an explicit waitpid with child pid given, lets wait for that pid
     int cage_id = pid;
-    
+
     /* make sure children exist (check children and zombies) */
     nap_child = DynArrayGet(&nap->children, cage_id);
     zombie = NaClCheckZombieById(nap, cage_id);
@@ -4942,6 +4942,8 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       ret = -NACL_ABI_ECHILD;
       goto out;
     }
+    
+    if (!zombie && (options & WNOHANG)) goto out; // exit here if WNOHANG, ret stays initialized to 0
 
     NaClLog(1, "Thread children count: %d\n", nap->num_children);
     /* wait for child to finish */

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4932,11 +4932,9 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
       zombie = NaClCheckZombies(nap); //re-check on signal
     }
 
-  } else {
-    // else we have an explicit waitpid with child pid given, lets wait for that pid
-
+  } else {   // else we have an explicit waitpid with child pid given, lets wait for that pid
     int cage_id = pid;
-
+    
     /* make sure children exist (check children and zombies) */
     nap_child = DynArrayGet(&nap->children, cage_id);
     zombie = NaClCheckZombieById(nap, cage_id);
@@ -4959,7 +4957,6 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   NaClRemoveZombie(nap, zombie->cage_id);
 
 out:
-  // NaClXCondVarBroadcast(&nap->children_cv);
   NaClXMutexUnlock(&nap->children_mu);
 
   NaClLog(1, "[NaClSysWaitpid] pid = %d \n", pid);

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -4901,19 +4901,11 @@ int32_t NaClSysWaitpid(struct NaClAppThread *natp,
   NaClLog(1, "%s\n", "[NaClSysWaitpid] entered waitpid!");
 
   CHECK(nap->num_children < NACL_THREAD_MAX);
-  if (stat_loc_ptr) {
-    *stat_loc_ptr = 0;
-  }
+  if (stat_loc_ptr) *stat_loc_ptr = 0;
 
-  // First check if we have children, if not check zombies, if no zombies return ECHILD
-  if (!nap->num_children || pid > pid_max) {
-    struct NaClZombie* zombie = NaClCheckZombies(nap);
-    if (zombie == NULL) ret = -NACL_ABI_ECHILD;
-    else {
-      ret = zombie->cage_id;
-        if (stat_loc_ptr) *stat_loc_ptr = zombie->exit_status;
-       NaClRemoveZombie(nap, zombie->cage_id);
-    }
+  // First check if we have children, if not return ECHILD
+  if (pid > pid_max || (!nap->num_children && !nap->zombies.num_entries)) {
+    ret = -NACL_ABI_ECHILD;
     goto out;
   }
 

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1990,6 +1990,15 @@ struct NaClZombie* NaClCheckZombies(struct NaClApp *nap) {
   return zombie;
 }
 
+struct NaClZombie* NaClCheckZombieById(struct NaClApp *nap, int cage_id) {
+  NaClXMutexLock(&nap->zombie_mu);
+  struct NaClZombie* zombie = NULL;
+  zombie = DynArrayGet(&nap->zombies, cage_id);
+  NaClXMutexUnlock(&nap->zombie_mu);
+
+  return zombie;
+}
+
 void NaClRemoveZombie(struct NaClApp *nap, int cage_id) {
   NaClXMutexLock(&nap->zombie_mu);
   struct NaClZombie* zombie = DynArrayGet(&nap->zombies, cage_id);

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1992,7 +1992,7 @@ struct NaClZombie* NaClCheckZombies(struct NaClApp *nap) {
 
 struct NaClZombie* NaClCheckZombieById(struct NaClApp *nap, int cage_id) {
   NaClXMutexLock(&nap->zombie_mu);
-  struct NaClZombie* zombie = NULL;
+  struct NaClZombie* zombie;
   zombie = DynArrayGet(&nap->zombies, cage_id);
   NaClXMutexUnlock(&nap->zombie_mu);
 

--- a/src/trusted/service_runtime/sel_ldr.c
+++ b/src/trusted/service_runtime/sel_ldr.c
@@ -1981,7 +1981,7 @@ int AllocNextFdBounded(struct NaClApp *nap, int lowerbound, struct NaClHostDesc 
 struct NaClZombie* NaClCheckZombies(struct NaClApp *nap) {
   NaClXMutexLock(&nap->zombie_mu);
   struct NaClZombie* zombie = NULL;
-  for(long unsigned int cage_id = 0; cage_id < nap->children.num_entries; cage_id++) {
+  for(long unsigned int cage_id = 0; cage_id < nap->zombies.num_entries; cage_id++) {
     zombie = DynArrayGet(&nap->zombies, cage_id);
     if (zombie != NULL) break;
   }

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -960,6 +960,7 @@ int AllocNextFd(struct NaClApp *nap, struct NaClHostDesc *hd);
 int AllocNextFdBounded(struct NaClApp *nap, int lowerbound, struct NaClHostDesc *hd);
 
 struct NaClZombie* NaClCheckZombies(struct NaClApp *nap);
+struct NaClZombie* NaClCheckZombieById(struct NaClApp *nap, int cage_id);
 void NaClRemoveZombie(struct NaClApp *nap, int cage_id);
 void NaClAddZombie(struct NaClApp *nap);
 


### PR DESCRIPTION
This refactors and fixes the entirety of waitpid. This started with fixing a backgrounding bug, but it revealed bugs elsewhere in waitpid when the pid is specified (it would formerly return if any cage had finished.

This refactors all of this to rely on the zombies list, which holds any cage that has exited. It also makes the mutex/CV scheme much more straightforward.