### PR TITLE
Thread Suspend CAS remove and  I/O bypass

### DIFF
--- a/src/shared/platform/lind_platform.h
+++ b/src/shared/platform/lind_platform.h
@@ -154,6 +154,9 @@ union RustArg {
 
 int dispatcher(unsigned long int cageid, int callnum, union RustArg arg1, union RustArg arg2,
                union RustArg arg3, union RustArg arg4, union RustArg arg5, union RustArg arg6);
+
+int quick_write(int fd, const void *buf, size_t count, int cageid);
+int quick_read(int fd, void *buf, int size, int cageid);
 void lindcancelinit(unsigned long int cageid);
 void lindsetthreadkill(unsigned long int cageid, unsigned long int pthreadid, bool kill);   
 bool lindcheckthread(unsigned long int cageid, unsigned long int pthreadid);

--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -244,7 +244,7 @@ void NaClThreadTrapUntrusted(struct NaClAppThread *natp) {
   old_state = natp->suspend_state;
   DCHECK((old_state & NACL_APP_THREAD_SUSPENDING) == 0);
   suspending_state = old_state | NACL_APP_THREAD_SUSPENDING;
-  natp->suspend_state = suspending_state);
+  natp->suspend_state = suspending_state;
 
   /*
    * Once the thread has NACL_APP_THREAD_SUSPENDING set, it may not

--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -244,6 +244,13 @@ void NaClThreadTrapUntrusted(struct NaClAppThread *natp) {
   old_state = natp->suspend_state;
   DCHECK((old_state & NACL_APP_THREAD_SUSPENDING) == 0);
   suspending_state = old_state | NACL_APP_THREAD_SUSPENDING;
+
+  /*
+   * Lind - we've removed a CAS instruction here, instead directly setting suspend state
+   * the previous CAS was due to Windows VMHole issues. This is far more performant and safe,
+   * since we're only compiling for Linux and these transitions are always contained within a single thread
+   */
+
   natp->suspend_state = suspending_state;
 
   /*
@@ -267,6 +274,12 @@ void NaClUntrustedThreadSuspend(struct NaClAppThread *natp,
   old_state = natp->suspend_state;
   DCHECK((old_state & NACL_APP_THREAD_SUSPENDING) == 0);
   suspending_state = old_state | NACL_APP_THREAD_SUSPENDING;
+
+  /*
+   * Lind - we've removed a CAS instruction here, instead directly setting suspend state
+   * the previous CAS was due to Windows VMHole issues. This is far more performant and safe,
+   * since we're only compiling for Linux and these transitions are always contained within a single thread
+   */
   natp->suspend_state = suspending_state;
 
   /* Once the thread has NACL_APP_THREAD_SUSPENDING set, it may not

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -685,14 +685,15 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   ssize_t         read_result = -NACL_ABI_EINVAL;
   uintptr_t       sysaddr;
   
-  NaClLog(2, "Cage %d Entered NaClSysRead(0x%08"NACL_PRIxPTR", "
-           "%d, 0x%08"NACL_PRIxPTR", "
-           "%"NACL_PRIdS"[0x%"NACL_PRIxS"])\n",
-          nap->cage_id, (uintptr_t) natp, d, (uintptr_t) buf, count, count);
+  // NaClLog(2, "Cage %d Entered NaClSysRead(0x%08"NACL_PRIxPTR", "
+  //          "%d, 0x%08"NACL_PRIxPTR", "
+  //          "%"NACL_PRIdS"[0x%"NACL_PRIxS"])\n",
+  //         nap->cage_id, (uintptr_t) natp, d, (uintptr_t) buf, count, count);
 
   if (d < 0) return -NACL_ABI_EBADF;
 
-  sysaddr = NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_WRITE);
+  sysaddr = buf + nap->mem_start;
+  //NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_WRITE);
   if (kNaClBadAddress == sysaddr) return -NACL_ABI_EFAULT;
   
 
@@ -780,14 +781,15 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   ssize_t         write_result = -NACL_ABI_EINVAL;
   uintptr_t       sysaddr;
 
-  NaClLog(2, "Cage %d Entered NaClSysWrite(0x%08"NACL_PRIxPTR", "
-        "%d, 0x%08"NACL_PRIxPTR", "
-        "%"NACL_PRIdS"[0x%"NACL_PRIxS"])\n",
-        nap->cage_id, (uintptr_t) natp, d, (uintptr_t) buf, count, count);
+  // NaClLog(2, "Cage %d Entered NaClSysWrite(0x%08"NACL_PRIxPTR", "
+  //       "%d, 0x%08"NACL_PRIxPTR", "
+  //       "%"NACL_PRIdS"[0x%"NACL_PRIxS"])\n",
+  //       nap->cage_id, (uintptr_t) natp, d, (uintptr_t) buf, count, count);
 
   if (d < 0) return -NACL_ABI_EBADF;
   
-  sysaddr = NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_READ);
+  sysaddr = buf + nap->mem_start;
+  //NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_READ);
   if (kNaClBadAddress == sysaddr) return -NACL_ABI_EFAULT;
   /*
    * The maximum length for read and write is INT32_MAX--anything larger and

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -692,8 +692,7 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
 
   if (d < 0) return -NACL_ABI_EBADF;
 
-  sysaddr = buf + nap->mem_start;
-  //NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_WRITE);
+  sysaddr = NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_WRITE);
   if (kNaClBadAddress == sysaddr) return -NACL_ABI_EFAULT;
   
 
@@ -710,9 +709,8 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
    * See note in sel_ldr.h
    */
   read_result = quick_read(d, (void *)sysaddr, count, nap->cage_id);
-  //lind_read(d, (void *)sysaddr, count, nap->cage_id);
+
   /* This cast is safe because we clamped count above.*/
-  
   retval = (int32_t) read_result;
   return retval;
 }
@@ -788,8 +786,7 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   if (d < 0) return -NACL_ABI_EBADF;
   
-  sysaddr = buf + nap->mem_start;
-  //NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_READ);
+  sysaddr = NaClUserToSysAddrRangeProt(nap, (uintptr_t) buf, count, NACL_ABI_PROT_READ);
   if (kNaClBadAddress == sysaddr) return -NACL_ABI_EFAULT;
   /*
    * The maximum length for read and write is INT32_MAX--anything larger and
@@ -802,7 +799,6 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
    * See note in sel_ldr.h
    */
   write_result = quick_write(d, (void *)sysaddr, count, nap->cage_id);
-  //lind_write(d, (void *)sysaddr, count, nap->cage_id);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t)write_result;

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -707,7 +707,10 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
 
   /* Lind - we removed the VMIOWillStart and End functions here, which is fine for Linux
    * See note in sel_ldr.h
+   *
+   * We bypass the dispatcher with quick_read to patch directly to RustPOSIX for performance efficiency 
    */
+  
   read_result = quick_read(d, (void *)sysaddr, count, nap->cage_id);
 
   /* This cast is safe because we clamped count above.*/
@@ -797,6 +800,8 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
 
   /* Lind - we removed the VMIOWillStart and End functions here, which is fine for Linux
    * See note in sel_ldr.h
+   *
+   * We bypass the dispatcher with quick_write to patch directly to RustPOSIX for performance efficiency 
    */
   write_result = quick_write(d, (void *)sysaddr, count, nap->cage_id);
 

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -708,7 +708,8 @@ int32_t NaClSysRead(struct NaClAppThread  *natp,
   /* Lind - we removed the VMIOWillStart and End functions here, which is fine for Linux
    * See note in sel_ldr.h
    */
-  read_result = lind_read(d, (void *)sysaddr, count, nap->cage_id);
+  read_result = quick_read(d, (void *)sysaddr, count, nap->cage_id);
+  //lind_read(d, (void *)sysaddr, count, nap->cage_id);
   /* This cast is safe because we clamped count above.*/
   
   retval = (int32_t) read_result;
@@ -798,7 +799,8 @@ int32_t NaClSysWrite(struct NaClAppThread *natp,
   /* Lind - we removed the VMIOWillStart and End functions here, which is fine for Linux
    * See note in sel_ldr.h
    */
-  write_result = lind_write(d, (void *)sysaddr, count, nap->cage_id);
+  write_result = quick_write(d, (void *)sysaddr, count, nap->cage_id);
+  //lind_write(d, (void *)sysaddr, count, nap->cage_id);
 
   /* This cast is safe because we clamped count above.*/
   retval = (int32_t)write_result;


### PR DESCRIPTION
Two performance improvements that yield 10% improvement on smaller buffers.

1. Circumvent the dispatcher on I/O calls with bypass functions.

2. Remove compare and swap from suspend functions. This only exists because of the Windows VMHole problem which we don't deal with, so we can save a lot of time by just changing the value instead of using CAS.