### PR TITLE
Fixed DISPATCH_SYSCALL macro used to invoke flock.

### DIFF
--- a/src/shared/platform/lind_platform.c
+++ b/src/shared/platform/lind_platform.c
@@ -341,9 +341,7 @@ int lind_getegid (int cageid) {
 }
 
 int lind_flock (int fd, int operation, int cageid) {
-    (void) fd;
-    (void) operation;
-    DISPATCH_SYSCALL_0(LIND_safe_fs_flock);
+    DISPATCH_SYSCALL_2(LIND_safe_fs_flock, int, fd, int, operation);
 }
 
 int lind_pipe(int* pipefds, int cageid) {


### PR DESCRIPTION
The arguments for `flock` that Native Client receives were not being passed to `safeposix`. This change fixes that so that the arguments are passed correctly.