### PR TITLE
remove lkm

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -39,7 +39,6 @@
 struct NaClMutex ccmut;
 struct NaClCondVar cccv;
 int cagecount;
-extern bool use_lkm;
 
 struct NaClThread reaper;
 
@@ -115,29 +114,13 @@ struct NaClApp *NaClChildNapCtor(struct NaClApp *nap, int child_cage_id, enum Na
   NaClXMutexUnlock(&nap_parent->children_mu);
 
   NaClLog(1, "fork_num = %d, cage_id = %d\n", fork_num, nap_child->cage_id);
-  if(!use_lkm || tl_type != THREAD_LAUNCH_FORK) {
-    //exec not prevalidated
-    if ((*mod_status = NaClAppLoadFileFromFilename(nap_child, nap_child->nacl_file)) != LOAD_OK) {
-      NaClLog(1, "Error while loading \"%s\": %s\n", nap_child->nacl_file, NaClErrorString(*mod_status));
-      NaClLog(LOG_FATAL, "%s\n%s\n",
-                         "Using the wrong type of nexe (nacl-x86-32 on an x86-64 or vice versa) ",
-                         "or a corrupt nexe file may be responsible for this error.");
-    }
-  } else {
-    //we already know the fork child has an ok nexe, and we don't even need to load it
-    nap_child->stack_size = nap_parent->stack_size;
-    nap_child->static_text_end = nap_parent->static_text_end;
-    nap_child->rodata_start = nap_parent->rodata_start;
-    nap_child->data_start = nap_parent->data_start;
-    nap_child->break_addr = nap_parent->break_addr;
-    nap_child->data_end = nap_parent->data_end;
-    nap_child->bundle_size = NACL_INSTR_BLOCK_SIZE;
-    nap_child->initial_entry_pt = nap_parent->initial_entry_pt;
-    nap_child->dynamic_text_start = nap_parent->dynamic_text_start;
-    nap_child->text_shm = nap_parent->text_shm;
-    NaClErrorCode err = NaClAllocAddrSpaceAslr(nap_child, NACL_ENABLE_ASLR);
-    if (err != LOAD_OK) NaClLog(LOG_FATAL, "%s\n", "NaClAllocAddrSpaceAslr failed. Terminating.");
-    NaClInitSwitchToApp(nap_child); 
+
+  //exec not prevalidated
+  if ((*mod_status = NaClAppLoadFileFromFilename(nap_child, nap_child->nacl_file)) != LOAD_OK) {
+    NaClLog(1, "Error while loading \"%s\": %s\n", nap_child->nacl_file, NaClErrorString(*mod_status));
+    NaClLog(LOG_FATAL, "%s\n%s\n",
+                        "Using the wrong type of nexe (nacl-x86-32 on an x86-64 or vice versa) ",
+                        "or a corrupt nexe file may be responsible for this error.");
   }
 
   if ((*mod_status = NaClAppPrepareToLaunch(nap_child)) != LOAD_OK) {

--- a/src/trusted/service_runtime/nacl_globals.c
+++ b/src/trusted/service_runtime/nacl_globals.c
@@ -35,7 +35,6 @@ int nacl_syscall_counter = 0;
 int nacl_syscall_trace_level_counter = 0;
 int nacl_syscall_invoked_times[NACL_MAX_SYSCALLS];
 double nacl_syscall_execution_time[NACL_MAX_SYSCALLS];
-bool use_lkm = true;
 
 void NaClGlobalModuleInit(void) {
   NaClInitGlobals();

--- a/src/trusted/service_runtime/sel_ldr.h
+++ b/src/trusted/service_runtime/sel_ldr.h
@@ -487,9 +487,6 @@ struct NaClApp {
   const struct NaClValidatorInterface *validator;
 };
 
-
-void CheckForLkm(void);
-
 void InitializeShmtable(void);
 void clear_shmentry(int shmid);
 

--- a/src/trusted/service_runtime/sel_main.c
+++ b/src/trusted/service_runtime/sel_main.c
@@ -76,7 +76,6 @@
 extern struct NaClMutex ccmut;
 extern struct NaClCondVar cccv;
 extern int cagecount;
-extern bool use_lkm;
 static void (*g_enable_outer_sandbox_func)(void) = NaClEnableOuterSandbox;
 
 void NaClSetEnableOuterSandboxFunc(void (*func)(void)) {
@@ -386,9 +385,6 @@ int NaClSelLdrMain(int argc, char **argv) {
         *redir_qend = entry;
         redir_qend = &entry->next;
         break;
-      case 'k':
-        use_lkm = false;
-        break;
       case 'l':
         log_file = optarg;
         break;
@@ -585,12 +581,6 @@ int NaClSelLdrMain(int argc, char **argv) {
   }
 
 #if NACL_LINUX
-
-  if(use_lkm) //in case we haven't forced not using the lkm with -k
-    CheckForLkm();
-  if(!use_lkm) {
-    fprintf(stderr, "Not using the CoW Loadable kernel module!\n");
-  }
   NaClSignalHandlerInit();
 #endif
   /*


### PR DESCRIPTION
## Description

Very simple changes, just removing any code involves loadable kernel modules. Most of the LKM related code are depend on the value of `use_lkm`, so I deleted the code being only executed when `use_lkm` is true, and only keep the code being executed when `use_lkm` is false. Besides, just remove the `checkForLKM()` function and it's reference.

### Type of change
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
## How Has This Been Tested?
passed the make test