### PR TITLE
nacl: return error if pointers are not aligned

### DIFF
--- a/src/trusted/service_runtime/sel_ldr-inl.h
+++ b/src/trusted/service_runtime/sel_ldr-inl.h
@@ -125,6 +125,9 @@ static INLINE uintptr_t NaClUserToSysAddrProt(struct NaClApp  *nap,
   if (0 == uaddr || ((uintptr_t) 1U << nap->addr_bits) <= uaddr) {
     return kNaClBadAddress;
   }
+  if (uaddr % 0x8 != 0) {
+    return kNaClBadAddress;
+  }
   if(!NaClVmmapCheckAddrMapping( &nap->mem_map, uaddr >> NACL_PAGESHIFT, 1, prot)){
     return kNaClBadAddress;
   }
@@ -146,6 +149,9 @@ static INLINE uintptr_t NaClUserToSysAddrRangeProt(struct NaClApp  *nap,
     return kNaClBadAddress;
   }
   if (((uintptr_t) 1U << nap->addr_bits) < end_addr) {
+    return kNaClBadAddress;
+  }
+  if (uaddr % 0x8 != 0) {
     return kNaClBadAddress;
   }
   if(!NaClVmmapCheckAddrMapping( &nap->mem_map, uaddr >> NACL_PAGESHIFT, count >> NACL_PAGESHIFT, prot)){


### PR DESCRIPTION
## Description

Fixes https://github.com/Lind-Project/lind_project/issues/327

Returning an error if pointer is not 8-byte aligned.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. -->
<!-- Provide instructions so we can reproduce. -->
<!-- Please also list any relevant details for your test configuration -->


Running test: hello.c        	TEST PASSED              
Running test: cpuid.c       	TEST PASSED               
Running test: dup2.c  	TEST PASSED              
Running test: dupwrite.c 	TEST PASSED                  
Running test: forkdup.c	TEST PASSED                 
Running test: write.c    	TEST PASSED           
Running test: forknodup.c      	TEST PASSED             
Running test: pipepong.c    	TEST PASSED                                                               
Running test: exit.c   TEST PASSED             
Running test: readbytes.c	TEST FAILED
Running test: writeloop.c	TEST FAILED
Running test: writepartial.c		TEST PASSED
Running test: noforkfiles.c	TEST PASSED
Running test: pread_pwrite.c	TEST PASSED
Running test: makepipe.c	TEST PASSED
Running test: mprotect.c	TEST PASSED
Running test: doubleclose.c	TEST PASSED
Running test: filetest.c	TEST PASSED 
Running test: filetest1000.c	TEST PASSED
Running test: mmaptest.c    	TEST PASSED
Running test: fstat.c      	TEST PASSED
Running test: stat.c	TEST PASSED
Running test: forkexecv.cTEST FAILED
Running test: socket.c	TEST PASSED
Running test: getuid.c   	TEST PASSED
Running test: forkexecuid.c    	TEST PASSED
Running test: ioctl.c 	TEST PASSED
Running test: setsid.c	TEST PASSED
Running test: dnstest.cTEST FAILED
Running test: cloexec.cTEST FAILED
Running test: chmod.c	TEST PASSED
Running test: rename.c	TEST PASSED
Running test: fchmod.c	TEST PASSED
Running test: truncate.c	TEST PASSED
Running test: mutex.c	TEST PASSED
Running test: socketpair.c	TEST PASSED
Running test: flock.c	TEST PASSED
Running test: getppid.c	TEST PASSED                                                                                                                           
Running test: creat_access.c	TEST PASSED
Running test: mkdir_rmdir.c	TEST PASSED
Running test: poll.c	TEST PASSED
Running test: sem_forks.c	TEST PASSED
Running test: fsync.cTEST FAILED
Running test: fdatasync.cTEST FAILED
Running test: sync_file_range.c	TEST PASSED
Running test: getpid.c	TEST PASSED
Running test: read.c	TEST PASSED
Running test: dup.c	TEST PASSED
Running test: fork.cTEST FAILED
Running test: fork2malloc.c	TEST PASSED
Running test: forkandopen.c	TEST PASSED
Running test: forkfiles.c	TEST PASSED
Running test: forkmalloc.c	TEST PASSED
Running test: pipe.cTEST FAILED
Running test: pipeinput.cTEST FAILED
Running test: pipeinput2.cTEST FAILED
Running test: pipewrite.c	TEST PASSED
Running test: pipeonestring.cTEST FAILED
Running test: chdir_getcwd.c	TEST PASSED
Running test: fchdir.c	TEST PASSED
Running test: segfault.cTEST FAILED
Running test: sysconf.c	TEST PASSED
Running test: template.c	TEST PASSED
Running test: gethostname.c	TEST PASSED
Running test: serverclient.c STUCK


## Checklist:

<!-- Add details about the checklist whenever needed -->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (lind-project, lind-glibc, safeposix-rust)
