### PR TITLE
Fix Program Counter on Fork

### DIFF
--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -545,6 +545,8 @@ void NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
     natp_child->user.r15 = nap_child->mem_start;
     natp_child->user.rsp = (uintptr_t)stack_ptr_child + stack_ptr_offset;
     natp_child->user.rbp = (uintptr_t)stack_ptr_child + base_ptr_offset;
+    natp_child->user.prog_ctr = (natp_child->user.prog_ctr & 0xffffffff) + nap_child->mem_start;
+    natp_child->user.new_prog_ctr = (natp_child->user.prog_ctr & 0xffffffff) + nap_child->mem_start;
     natp_child->user.sysret = 0;
 
   /* examine arbitrary stack values */

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -546,7 +546,7 @@ void NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
     natp_child->user.rsp = (uintptr_t)stack_ptr_child + stack_ptr_offset;
     natp_child->user.rbp = (uintptr_t)stack_ptr_child + base_ptr_offset;
     natp_child->user.prog_ctr = (natp_child->user.prog_ctr & 0xffffffff) + nap_child->mem_start;
-    natp_child->user.new_prog_ctr = (natp_child->user.prog_ctr & 0xffffffff) + nap_child->mem_start;
+    natp_child->user.new_prog_ctr = (natp_child->user.new_prog_ctr & 0xffffffff) + nap_child->mem_start;
     natp_child->user.sysret = 0;
 
   /* examine arbitrary stack values */

--- a/src/trusted/service_runtime/nacl_app_thread.c
+++ b/src/trusted/service_runtime/nacl_app_thread.c
@@ -545,8 +545,8 @@ void NaClForkThreadContextSetup(struct NaClAppThread     *natp_parent,
     natp_child->user.r15 = nap_child->mem_start;
     natp_child->user.rsp = (uintptr_t)stack_ptr_child + stack_ptr_offset;
     natp_child->user.rbp = (uintptr_t)stack_ptr_child + base_ptr_offset;
-    natp_child->user.prog_ctr = (natp_child->user.prog_ctr & 0xffffffff) + nap_child->mem_start;
-    natp_child->user.new_prog_ctr = (natp_child->user.new_prog_ctr & 0xffffffff) + nap_child->mem_start;
+    natp_child->user.prog_ctr = (natp_child->user.prog_ctr & UNTRUSTED_ADDR_MASK) + nap_child->mem_start;
+    natp_child->user.new_prog_ctr = (natp_child->user.new_prog_ctr & UNTRUSTED_ADDR_MASK) + nap_child->mem_start;
     natp_child->user.sysret = 0;
 
   /* examine arbitrary stack values */


### PR DESCRIPTION
## Description

This fixes a segfault in situations where a child cage is forked and the parent immediately exists. Here the child program counter isnt properly adjusted and still points to the parents address space. Because the parent frees its address space, the program faults. It's pretty crazy that this one took this long to catch, but because of how NaCl is setup, as long as it enters the code correctly the addresses are then properly located after the point of entry which made this tricky to find.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

All test suites and applications

## Checklist:
- [x] My code follows the style guidelines of this project
- [x ] My changes generate no new warnings

