### PR TITLE
Strace update

### DIFF
--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -3494,18 +3494,8 @@ int32_t NaClSysGetTimeOfDay(struct NaClAppThread      *natp,
    * TODO(bsy) Do we make the zoneinfo directory available to
    * applications?
    */
-  #ifdef TRACING
-  long long starttime = gettimens();
-  #endif
 
   retval = NaClGetTimeOfDay(&now);
-  if (retval) {
-      #ifdef TRACING
-      long long endtime = gettimens();
-      long long totaltime = endtime - starttime;
-      NaClStraceGetTimeOfDay(natp->nap->cage_id, (uintptr_t) tv, (uintptr_t) tz, retval, totaltime);
-      #endif
-  }
 #if !NACL_WINDOWS
   /*
    * Coarsen the time to the same level we get on Windows -
@@ -3546,10 +3536,6 @@ int32_t NaClSysClockGetCommon(struct NaClAppThread  *natp,
   int                       retval = -NACL_ABI_EINVAL;
   struct nacl_abi_timespec  out_buf;
 
-  #ifdef TRACING
-  long long starttime = gettimens();
-  #endif
-
   if (!NaClIsValidClockId(clk_id)) {
     goto done;
   }
@@ -3560,11 +3546,6 @@ int32_t NaClSysClockGetCommon(struct NaClAppThread  *natp,
 
  done:
 
-  #ifdef TRACING
-  long long endtime = gettimens();
-  long long totaltime = endtime - starttime;
-  NaClStraceClockGetCommon(nap->cage_id, clk_id, ts_addr,time_func, retval, totaltime);
-  #endif
 
   return retval;
 }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -791,8 +791,8 @@ void printFinalSyscallStats() {
 
         qsort(syscallTimes, validCount, sizeof(SyscallTime), compareSyscallTime);
 
-        fprintf(tracingOutputFile, "%% time     seconds  usecs/call  calls    errors   syscall\n");
-        fprintf(tracingOutputFile, "------ ----------- ----------- --------- -------   ----------------\n");
+        fprintf(tracingOutputFile, "%% time     seconds  usecs/call  calls  errors   syscall\n");
+        fprintf(tracingOutputFile, "------ ----------- ----------- ------- -------   ----------------\n");
 
         // Print each syscall's stats to the tracing output file
         for (int i = 0; i < validCount; i++) {

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -807,7 +807,7 @@ void printFinalSyscallStats() {
 
             snprintf(formattedSeconds, sizeof(formattedSeconds), "%.*f", decimalPrecision, seconds);
 
-            fprintf(tracingOutputFile, "%05.2f  %s        %7lld    %6lld  %6lld   %s\n",
+            fprintf(tracingOutputFile, "%05.2f  %s        %7lld    %7lld  %6lld   %s\n",
                    syscallTimes[i].percentTime,
                    formattedSeconds,
                    syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0,

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -820,7 +820,7 @@ void printFinalSyscallStats() {
 
             snprintf(formattedSeconds, sizeof(formattedSeconds), "%.*f", decimalPrecision, seconds);
 
-            fprintf(tracingOutputFile, "%05.2f  %s        %7lld      %*lld  %*lld   %s\n",
+            fprintf(tracingOutputFile, "%05.2f  %s        %7lld      %*lld %*lld   %s\n",
                    syscallTimes[i].percentTime,
                    formattedSeconds,
                    syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0,
@@ -838,7 +838,7 @@ void printFinalSyscallStats() {
         snprintf(formattedSeconds, sizeof(formattedSeconds), "%.*f", totalDecimalPrecision, totalSecondsFormatted);
 
         fprintf(tracingOutputFile, "------ -------------- ----------- %-*s %-*s ----------------\n",
-                maxCallDigits, "---------", maxErrorDigits, "-------");
+                maxCallDigits, "---------", maxErrorDigits, "---------");
         fprintf(tracingOutputFile, "100.00 %s          0           %*lld  %*lld   total\n",
                 formattedSeconds, maxCallDigits, totalCalls, maxErrorDigits, totalErrors);
     }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -981,9 +981,9 @@ const char * getSyscallName(int syscallIndex) {
   case NACL_sys_execv:
     return "execv";
   case NACL_sys_mprotect:
-    return "mprotect"
+    return "mprotect";
   case NACL_sys_brk:
-    return "brk"
+    return "brk";
   default:
     return "unknown";
   }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -980,6 +980,10 @@ const char * getSyscallName(int syscallIndex) {
     return "getifaddrs";
   case NACL_sys_execv:
     return "execv";
+  case NACL_sys_mprotect:
+    return "mprotect"
+  case NACL_sys_brk:
+    return "brk"
   default:
     return "unknown";
   }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -728,7 +728,7 @@ void NaClStraceFcntlGet(int cageid, int fd, int cmd, int ret, long long totaltim
     fprintf(tracingOutputFile, "%d fcntlget(%d, %d) = %d\n", cageid, fd, cmd, ret);
   }
 }
-
+//both NACL_sys_fcntl_get and NACL_sys_fcntl_set are combined
 void NaClStraceFcntlSet(int cageid, int fd, int cmd, long set_op, int ret, long long totaltime) {
   if (strace_C) {
     stracec_increment(NACL_sys_fcntl_get, totaltime, ret);
@@ -736,10 +736,10 @@ void NaClStraceFcntlSet(int cageid, int fd, int cmd, long set_op, int ret, long 
     fprintf(tracingOutputFile, "%d fcntlset(%d, %d, %ld) = %d\n", cageid, fd, cmd, set_op, ret);
   }
 }
-//both NACL_sys_fcntl_get and NACL_sys_fcntl_set are combined
+
 void NaClStraceEpollCreate(int cageid, int size, int ret, long long totaltime) {
   if (strace_C) {
-    stracec_increment_fcntl(NACL_sys_fcntl_set, totaltime, ret);
+    stracec_increment(NACL_sys_epoll_create, totaltime, ret);
   } else {
     fprintf(tracingOutputFile, "%d epollcreate(%d) = %d\n", cageid, size, ret);
   }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -807,7 +807,7 @@ void printFinalSyscallStats() {
 
             snprintf(formattedSeconds, sizeof(formattedSeconds), "%.*f", decimalPrecision, seconds);
 
-            fprintf(tracingOutputFile, "%05.2f  %s   %7lld  %6lld   %6lld         %s\n",
+            fprintf(tracingOutputFile, "%05.2f  %s        %7lld    %6lld  %6lld   %s\n",
                    syscallTimes[i].percentTime,
                    formattedSeconds,
                    syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0,
@@ -826,7 +826,7 @@ void printFinalSyscallStats() {
         snprintf(formattedSeconds, sizeof(formattedSeconds), "%.*f", totalDecimalPrecision, totalSecondsFormatted);
 
         fprintf(tracingOutputFile, "------ ----------- ----------- --------- -------   ----------------\n");
-        fprintf(tracingOutputFile, "100.00  %s         0   %6lld  %6lld            total\n", formattedSeconds, totalCalls, totalErrors);
+        fprintf(tracingOutputFile, "100.00 %s          0        %6lld  %6lld   total\n", formattedSeconds, totalCalls, totalErrors);
     }
 }
 // Helper function to get syscall name from its index

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -808,17 +808,22 @@ void printFinalSyscallStats() {
         // Print each syscall's stats to the tracing output file
         for (int i = 0; i < validCount; i++) {
             int idx = syscallTimes[i].index;
-            fprintf(tracingOutputFile, "%05.2f  %7.4f   %7lld   %6lld  %6lld     %s\n",
+            double seconds = (double)syscallStats[idx].totalTime / 1000000000.0;
+            int beforeDecimal = seconds > 0 ? (int)log10(seconds) + 1 : 1;
+            int afterDecimal = 6 - beforeDecimal; // Ensure total of 7 places
+            if (afterDecimal < 0) afterDecimal = 0; // Cannot have negative precision
+
+            fprintf(tracingOutputFile, "%05.2f  %*.*f   %7lld   %6lld  %6lld     %s\n",
                    syscallTimes[i].percentTime,
-                   (double)syscallStats[idx].totalTime / 1000000000.0,
-                   syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0, // Calculate usecs/call
+                   7, afterDecimal,seconds,
+                   syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0,
                    syscallStats[idx].count,
                    syscallStats[idx].errorCount,
                    getSyscallName(idx));
         }
 
         // Print the total summary line to the tracing output file
-        fprintf(tracingOutputFile, "------ ----------- ----------- ------- -------   ----------------\n");
+        fprintf(tracingOutputFile, "------ ----------- ----------- --------- -------   ----------------\n");
         fprintf(tracingOutputFile, "100.00  %7.4f      0   %6lld  %6lld            total\n", totalSeconds, totalCalls, totalErrors);
     }
 }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -537,7 +537,7 @@ void NaClStraceSocket(int cageid, int domain, int type, int protocol, int ret, l
 void NaClStraceSend(int cageid, int sockfd,
   const void * buf, size_t len, int flags, int ret, long long totaltime) {
   if (strace_C) {
-    stracec_increment(NACL_sys_send, totaltime, ret);
+    stracec_increment(NACL_sys_sendto, totaltime, ret);
   } else {
     fprintf(tracingOutputFile, "%d send(%d, 0x%08"NACL_PRIxPTR ", %ld, %d) = %d\n", cageid, sockfd, (uintptr_t) buf, len, flags, ret);
   }
@@ -554,7 +554,7 @@ void NaClStraceSendto(int cageid, int sockfd,
 
 void NaClStraceRecv(int cageid, int sockfd, void * buf, size_t len, int flags, int ret, long long totaltime) {
   if (strace_C) {
-    stracec_increment(NACL_sys_recv, totaltime, ret);
+    stracec_increment(NACL_sys_recvfrom, totaltime, ret);
   } else {
     fprintf(tracingOutputFile, "%d recv(%d, 0x%08"NACL_PRIxPTR ", %ld, %d) = %d\n", cageid, sockfd, (uintptr_t) buf, len, flags, ret);
   }
@@ -895,11 +895,11 @@ const char * getSyscallName(int syscallIndex) {
   case NACL_sys_socket:
     return "socket";
   case NACL_sys_send:
-    return "send";
+    return "sendto";
   case NACL_sys_sendto:
     return "sendto";
   case NACL_sys_recv:
-    return "recv";
+    return "recvfrom";
   case NACL_sys_recvfrom:
     return "recvfrom";
   case NACL_sys_shmat:

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -808,22 +808,17 @@ void printFinalSyscallStats() {
         // Print each syscall's stats to the tracing output file
         for (int i = 0; i < validCount; i++) {
             int idx = syscallTimes[i].index;
-            double seconds = (double)syscallStats[idx].totalTime / 1000000000.0;
-            int beforeDecimal = seconds > 0 ? (int)log10(seconds) + 1 : 1;
-            int afterDecimal = 6 - beforeDecimal; // Ensure total of 7 places
-            if (afterDecimal < 0) afterDecimal = 0; // Cannot have negative precision
-
-            fprintf(tracingOutputFile, "%05.2f  %*.*f   %7lld   %6lld  %6lld     %s\n",
+            fprintf(tracingOutputFile, "%05.2f  %7.4f   %7lld   %6lld  %6lld     %s\n",
                    syscallTimes[i].percentTime,
-                   7, afterDecimal,seconds,
-                   syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0,
+                   (double)syscallStats[idx].totalTime / 1000000000.0,
+                   syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0, // Calculate usecs/call
                    syscallStats[idx].count,
                    syscallStats[idx].errorCount,
                    getSyscallName(idx));
         }
 
         // Print the total summary line to the tracing output file
-        fprintf(tracingOutputFile, "------ ----------- ----------- --------- -------   ----------------\n");
+        fprintf(tracingOutputFile, "------ ----------- ----------- ------- -------   ----------------\n");
         fprintf(tracingOutputFile, "100.00  %7.4f      0   %6lld  %6lld            total\n", totalSeconds, totalCalls, totalErrors);
     }
 }

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -539,7 +539,7 @@ void NaClStraceSend(int cageid, int sockfd,
   if (strace_C) {
     stracec_increment(NACL_sys_sendto, totaltime, ret);
   } else {
-    fprintf(tracingOutputFile, "%d send(%d, 0x%08"NACL_PRIxPTR ", %ld, %d) = %d\n", cageid, sockfd, (uintptr_t) buf, len, flags, ret);
+    fprintf(tracingOutputFile, "%d sendto(%d, 0x%08"NACL_PRIxPTR ", %ld, %d) = %d\n", cageid, sockfd, (uintptr_t) buf, len, flags, ret);
   }
 }
 
@@ -556,7 +556,7 @@ void NaClStraceRecv(int cageid, int sockfd, void * buf, size_t len, int flags, i
   if (strace_C) {
     stracec_increment(NACL_sys_recvfrom, totaltime, ret);
   } else {
-    fprintf(tracingOutputFile, "%d recv(%d, 0x%08"NACL_PRIxPTR ", %ld, %d) = %d\n", cageid, sockfd, (uintptr_t) buf, len, flags, ret);
+    fprintf(tracingOutputFile, "%d recvfrom(%d, 0x%08"NACL_PRIxPTR ", %ld, %d) = %d\n", cageid, sockfd, (uintptr_t) buf, len, flags, ret);
   }
 }
 
@@ -808,7 +808,7 @@ void printFinalSyscallStats() {
         // Print each syscall's stats to the tracing output file
         for (int i = 0; i < validCount; i++) {
             int idx = syscallTimes[i].index;
-            fprintf(tracingOutputFile, "%05.2f  %7.4f   %7lld   %6lld  %6lld     %s\n",
+            fprintf(tracingOutputFile, "%05.2f  %0.9f   %7lld   %6lld  %6lld     %s\n",
                    syscallTimes[i].percentTime,
                    (double)syscallStats[idx].totalTime / 1000000000.0,
                    syscallStats[idx].count > 0 ? syscallStats[idx].totalTime / syscallStats[idx].count / 1000 : 0, // Calculate usecs/call
@@ -819,7 +819,7 @@ void printFinalSyscallStats() {
 
         // Print the total summary line to the tracing output file
         fprintf(tracingOutputFile, "------ ----------- ----------- ------- -------   ----------------\n");
-        fprintf(tracingOutputFile, "100.00  %7.4f      0   %6lld  %6lld            total\n", totalSeconds, totalCalls, totalErrors);
+        fprintf(tracingOutputFile, "100.00  %0.9f      0   %6lld  %6lld            total\n", totalSeconds, totalCalls, totalErrors);
     }
 }
 

--- a/src/trusted/service_runtime/nacl_syscall_strace.c
+++ b/src/trusted/service_runtime/nacl_syscall_strace.c
@@ -721,17 +721,6 @@ void NaClStraceBrk(int cageid, uintptr_t new_break, int32_t ret, long long total
   }
 }
 
-void stracec_increment_fcntl(int syscallnum, long long totaltime, int retval) {
-    if (syscallnum == NACL_sys_fcntl_set) {
-        syscallnum = NACL_sys_fcntl_get; 
-    syscallStats[syscallnum].count++;
-    syscallStats[syscallnum].totalTime += totaltime;
-    if (retval < 0) {
-        syscallStats[syscallnum].errorCount++;
-    }
-  }
-}
-
 void NaClStraceFcntlGet(int cageid, int fd, int cmd, int ret, long long totaltime) {
   if (strace_C) {
     stracec_increment(NACL_sys_fcntl_get, totaltime, ret);
@@ -742,12 +731,12 @@ void NaClStraceFcntlGet(int cageid, int fd, int cmd, int ret, long long totaltim
 
 void NaClStraceFcntlSet(int cageid, int fd, int cmd, long set_op, int ret, long long totaltime) {
   if (strace_C) {
-    stracec_increment_fcntl(NACL_sys_fcntl_get, totaltime, ret);
+    stracec_increment(NACL_sys_fcntl_get, totaltime, ret);
   } else {
     fprintf(tracingOutputFile, "%d fcntlset(%d, %d, %ld) = %d\n", cageid, fd, cmd, set_op, ret);
   }
 }
-
+//both NACL_sys_fcntl_get and NACL_sys_fcntl_set are combined
 void NaClStraceEpollCreate(int cageid, int size, int ret, long long totaltime) {
   if (strace_C) {
     stracec_increment_fcntl(NACL_sys_fcntl_set, totaltime, ret);

--- a/src/trusted/service_runtime/nacl_syscall_strace.h
+++ b/src/trusted/service_runtime/nacl_syscall_strace.h
@@ -45,8 +45,6 @@ void NaClStraceShmget(int cageid, int key, size_t size, int shmflg, int retval, 
 void NaClStraceShmdt(int cageid, void *shmaddr, int retval, long long totaltime) ;
 void NaClStraceShmctl(int cageid, int shmid, int cmd, uintptr_t bufsysaddr, int retval, long long totaltime) ;
 void NaClStraceSocketPair(int cageid, int domain, int type, int protocol, int *lindfds, int retval, long long totaltime) ;
-void NaClStraceGetTimeOfDay(int cageid, uintptr_t tv, uintptr_t tz, int ret, long long totaltime) ;
-void NaClStraceClockGetCommon(int cageid, int clk_id, uint32_t ts_addr, uintptr_t *time_func, int ret, long long totaltime) ;
 void NaClStraceFork(int cageid, int ret, long long totaltime) ;
 void NaClStraceExecve(int cageid, char const *path, char *const *argv, int ret, long long totaltime) ;
 void NaClStraceExecv(int cageid, char const *path, char *const *argv, int ret, long long totaltime) ;
@@ -78,6 +76,9 @@ void NaClStraceAccept(int cageid, int sockfd, uintptr_t addr, socklen_t *addrlen
 void NaClStraceBind(int cageid, int sockfd, uintptr_t addr, socklen_t addrlen, int ret, long long totaltime) ;
 void NaClStraceListen(int cageid, int sockfd, int backlog, int ret, long long totaltime) ;
 void NaClStracePoll(int cageid, uintptr_t fds, nfds_t nfds, int timeout, int retval, long long totaltime) ;
+void NaClStraceMprotect(int cageid, uint32_t start, size_t length, int prot, int32_t ret, long long totaltime) ;
+void NaClStraceBrk(int cageid, uintptr_t new_break, int32_t ret, long long totaltime) ;
+void stracec_increment_fcntl(int syscallnum, long long totaltime, int retval) ;
 void NaClStraceFcntlGet(int cageid, int fd, int cmd, int ret, long long totaltime) ;
 void NaClStraceFcntlSet(int cageid, int fd, int cmd, long set_op, int ret, long long totaltime) ;
 void NaClStraceEpollCreate(int cageid, int size, int ret, long long totaltime) ;

--- a/src/trusted/service_runtime/nacl_syscall_strace.h
+++ b/src/trusted/service_runtime/nacl_syscall_strace.h
@@ -78,7 +78,6 @@ void NaClStraceListen(int cageid, int sockfd, int backlog, int ret, long long to
 void NaClStracePoll(int cageid, uintptr_t fds, nfds_t nfds, int timeout, int retval, long long totaltime) ;
 void NaClStraceMprotect(int cageid, uint32_t start, size_t length, int prot, int32_t ret, long long totaltime) ;
 void NaClStraceBrk(int cageid, uintptr_t new_break, int32_t ret, long long totaltime) ;
-void stracec_increment_fcntl(int syscallnum, long long totaltime, int retval) ;
 void NaClStraceFcntlGet(int cageid, int fd, int cmd, int ret, long long totaltime) ;
 void NaClStraceFcntlSet(int cageid, int fd, int cmd, long set_op, int ret, long long totaltime) ;
 void NaClStraceEpollCreate(int cageid, int size, int ret, long long totaltime) ;


### PR DESCRIPTION
## Description
* Seconds column now displays up to 7 digits for uniformity.
* Added naclsysbrk and naclsysmprotect syscalls.
*  Excluded time & clock-related syscalls and unified fnctl operations. Merged send/recv stats into sendto/recvfrom .

### Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

<!-- Add details about the checklist whenever needed -->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to a pull request and/or merged in other modules (lind-project, lind-glibc, safeposix-rust)
