### PR TITLE
Remove unneeded CAS in main syscall path

### DIFF
--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -65,9 +65,9 @@ void NaClAppThreadSetSuspendState(struct NaClAppThread *natp,
                                   enum NaClSuspendState old_state,
                                   enum NaClSuspendState new_state) {
   while (1) {
-    if (new_state == old_state) break;
     int state = natp->suspend_state;
     natp->suspend_state = new_state;
+    if (state == old_state) break;
 
     /*
     * Lind - we've removed a CAS instruction here, instead directly setting suspend state

--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -65,9 +65,9 @@ void NaClAppThreadSetSuspendState(struct NaClAppThread *natp,
                                   enum NaClSuspendState old_state,
                                   enum NaClSuspendState new_state) {
   while (1) {
-    Atomic32 state = natp->suspend_state;
+    unsigned int state = natp->suspend_state;
     natp->suspend_state = new_state;
-    if (state == old_state) break;
+    if (state == (unsigned int)old_state) break;
 
     /*
     * Lind - we've removed a CAS instruction here, instead directly setting suspend state

--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -65,10 +65,15 @@ void NaClAppThreadSetSuspendState(struct NaClAppThread *natp,
                                   enum NaClSuspendState old_state,
                                   enum NaClSuspendState new_state) {
   while (1) {
-    if (old_state == new_state) break;
-    natp->suspend_state =  new_state;
+    if (new_state == old_state) break;
+    int state = natp->suspend_state;
+    natp->suspend_state = new_state;
 
-    state = natp->suspend_state;
+    /*
+    * Lind - we've removed a CAS instruction here, instead directly setting suspend state
+    * the previous CAS was due to Windows VMHole issues. This is far more performant and safe,
+    * since we're only compiling for Linux and these transitions are always contained within a single thread
+    */
 
     if ((state & NACL_APP_THREAD_SUSPENDING) != 0) {
       struct NaClThread *host_thread;

--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -65,10 +65,11 @@ void NaClAppThreadSetSuspendState(struct NaClAppThread *natp,
                                   enum NaClSuspendState old_state,
                                   enum NaClSuspendState new_state) {
   while (1) {
-    Atomic32 state = CompareAndSwap(&natp->suspend_state, old_state, new_state);
-    if (NACL_LIKELY(state == (Atomic32) old_state)) {
-      break;
-    }
+    if (old_state == new_state) break;
+    natp->suspend_state =  new_state;
+
+    state = natp->suspend_state;
+
     if ((state & NACL_APP_THREAD_SUSPENDING) != 0) {
       struct NaClThread *host_thread;
       host_thread = &natp->host_thread;

--- a/src/trusted/service_runtime/linux/thread_suspension.c
+++ b/src/trusted/service_runtime/linux/thread_suspension.c
@@ -65,7 +65,7 @@ void NaClAppThreadSetSuspendState(struct NaClAppThread *natp,
                                   enum NaClSuspendState old_state,
                                   enum NaClSuspendState new_state) {
   while (1) {
-    int state = natp->suspend_state;
+    Atomic32 state = natp->suspend_state;
     natp->suspend_state = new_state;
     if (state == old_state) break;
 


### PR DESCRIPTION
## Description

Fixes # (issue)

Removes compare and swap from main syscall path. Not need in Linux because of no vmhole (see note in code).

### Type of change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

All test suites and LAMP apps.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

