### PR TITLE
Fix Exit Ordering

### DIFF
--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -410,7 +410,6 @@ int32_t NaClSysExit(struct NaClAppThread *natp, int status) {
   long long starttime = gettimens();
   #endif
 
-    lind_exit(status, nap->cage_id);
 
     #ifdef TRACING
     long long endtime = gettimens();
@@ -420,6 +419,8 @@ int32_t NaClSysExit(struct NaClAppThread *natp, int status) {
 
     NaClLog(1, "Exit syscall handler: %d\n", status);
     (void)NaClReportExitStatus(nap, NACL_ABI_W_EXITCODE(status, 0));
+    lind_exit(status, nap->cage_id);
+
     NaClAppThreadTeardown(natp);
 
     /* NOTREACHED */

--- a/src/trusted/service_runtime/nacl_syscall_common.c
+++ b/src/trusted/service_runtime/nacl_syscall_common.c
@@ -406,20 +406,19 @@ int32_t NaClSysExit(struct NaClAppThread *natp, int status) {
         NaClExitThreadGroup(natp);
     }
 
-  #ifdef TRACING
-  long long starttime = gettimens();
-  #endif
+    #ifdef TRACING
+    long long starttime = gettimens();
+    #endif
 
+    NaClLog(1, "Exit syscall handler: %d\n", status);
+    (void)NaClReportExitStatus(nap, NACL_ABI_W_EXITCODE(status, 0)); // need to report here first so we add exited process as a zombie for wait
+    lind_exit(status, nap->cage_id); // before lind_exit sends SIGCHLD
 
     #ifdef TRACING
     long long endtime = gettimens();
     long long totaltime = endtime - starttime;
     NaClStraceExit(nap->cage_id, status, totaltime);
     #endif
-
-    NaClLog(1, "Exit syscall handler: %d\n", status);
-    (void)NaClReportExitStatus(nap, NACL_ABI_W_EXITCODE(status, 0));
-    lind_exit(status, nap->cage_id);
 
     NaClAppThreadTeardown(natp);
 


### PR DESCRIPTION
## Description
Fixes # (issue)

Fixes concurrency bug that shows up in nginx where a non-blocking wait tries to happen before the exited process is added to the exited list.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Lind Suite
Lamp Tests

## Checklist:
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
